### PR TITLE
Update default WiFi placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # RiddleMatrix
+
+## Configuration
+
+The `config.h` file contains placeholder WiFi credentials used when no
+settings are stored in EEPROM. Real network credentials should **not** be
+committed to the repository. Instead, provide them through the initial EEPROM
+setup or via the device's configuration screen.

--- a/config.h
+++ b/config.h
@@ -173,11 +173,11 @@ void loadConfig() {
     bool eepromUpdated = false;
 
     // **Falls EEPROM leer oder beschädigt, Standardwerte setzen**
-    if (wifi_ssid.length() == 0 || ssidArr[0] == '\xFF') {  
+    if (wifi_ssid.length() == 0 || ssidArr[0] == '\xFF') {
         Serial.println("🛑 Kein gültiges WiFi im EEPROM gefunden! Setze Standardwerte...");
-        wifi_ssid = "Traumland_Maerchen";
-        wifi_password = "MaerchenByLothar";
-        hostname = "traumland.maerchen";
+        wifi_ssid = "YOUR_WIFI_SSID";
+        wifi_password = "YOUR_WIFI_PASSWORD";
+        hostname = "your-device-hostname";
         eepromUpdated = true;
     }
 


### PR DESCRIPTION
## Summary
- replace demo WiFi defaults in `config.h` with placeholders
- document WiFi credential setup in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688155802b388330800669df8f24113e