### PR TITLE
Add configurable WiFi connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See [TODO.md](TODO.md) for the project roadmap.
 
 ## WiFi Configuration
 
-1. Open `config.h` and edit `wifi_ssid`, `wifi_password` and `hostname` in `saveConfig()`.
+1. Open `config.h` and edit `wifi_ssid`, `wifi_password`, `hostname` and optionally `wifi_connect_timeout` in `saveConfig()`.
 2. Compile and upload the firmware.
 3. Once connected to your network, visit `http://<hostname>` and use the web page to store updated credentials in EEPROM.
 
@@ -48,3 +48,5 @@ The `config.h` file contains placeholder WiFi credentials used when no
 settings are stored in EEPROM. Real network credentials should **not** be
 committed to the repository. Instead, provide them through the initial EEPROM
 setup or via the device's configuration screen.
+The `wifi_connect_timeout` setting controls how long the device will attempt to
+connect to WiFi before giving up. The default is 30 seconds.

--- a/src/config.h
+++ b/src/config.h
@@ -36,6 +36,7 @@
 String wifi_ssid;
 String wifi_password;
 String hostname;
+int wifi_connect_timeout = 30; // Timeout for WiFi connection in seconds
 
 // **Globale Variablen für die Anzeige**
 
@@ -116,7 +117,9 @@ void saveConfig() {
     EEPROM.put(316, letter_trigger_delay_3);
     EEPROM.put(320, letter_auto_display_interval);
     uint8_t autoModeByte = autoDisplayMode ? 1 : 0;
-    EEPROM.put(324, autoModeByte);    EEPROM.commit();
+    EEPROM.put(324, autoModeByte);
+    EEPROM.put(328, wifi_connect_timeout);
+    EEPROM.commit();
 
     Serial.println("✅ Einstellungen erfolgreich gespeichert!");
 }
@@ -158,6 +161,7 @@ void loadConfig() {
     EEPROM.get(320, letter_auto_display_interval);
     uint8_t autoModeByte;
     EEPROM.get(324, autoModeByte);
+    EEPROM.get(328, wifi_connect_timeout);
     autoDisplayMode = (autoModeByte == 1);
 
     wifi_ssid = String(ssidArr);
@@ -178,6 +182,7 @@ void loadConfig() {
         wifi_ssid = "YOUR_WIFI_SSID";
         wifi_password = "YOUR_WIFI_PASSWORD";
         hostname = "your-device-hostname";
+        wifi_connect_timeout = 30;
         eepromUpdated = true;
     }
 
@@ -229,6 +234,12 @@ void loadConfig() {
     if (letter_auto_display_interval < 1 || letter_auto_display_interval > 999) {
         Serial.println("🛑 Ungültiges Automodus-Intervall! Setze Standardwert...");
         letter_auto_display_interval = 300;  // **5 Minuten**
+        eepromUpdated = true;
+    }
+
+    if (wifi_connect_timeout < 1 || wifi_connect_timeout > 300) {
+        Serial.println("🛑 Ungültiger WiFi-Timeout! Setze Standardwert...");
+        wifi_connect_timeout = 30;  // **30 Sekunden**
         eepromUpdated = true;
     }
 

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -70,11 +70,15 @@ void connectWiFi() {
     WiFi.hostname(hostname.c_str());
     WiFi.begin(wifi_ssid.c_str(), wifi_password.c_str());
 
-    int attempt = 0;
-    while (WiFi.status() != WL_CONNECTED && attempt < 3200) {
-        attempt++;
-        delay(50);
-        if (attempt % 40 == 0) Serial.print(".");
+    unsigned long startAttempt = millis();
+    unsigned long lastDot = startAttempt;
+    while (WiFi.status() != WL_CONNECTED &&
+           (millis() - startAttempt < (wifi_connect_timeout * 1000UL))) {
+        if (millis() - lastDot >= 2000) {
+            Serial.print(".");
+            lastDot = millis();
+        }
+        delay(10);
     }
 
     if (WiFi.status() == WL_CONNECTED) {


### PR DESCRIPTION
## Summary
- allow specifying WiFi connection timeout via `wifi_connect_timeout`
- store the new setting in EEPROM
- use `millis()` instead of a large delay loop when connecting
- document the new option in the README

## Testing
- `platformio run` *(fails: UnknownPackageError for PxMatrix)*

------
https://chatgpt.com/codex/tasks/task_e_6881ce00f1bc8330b85085f90513692d