### PR TITLE
Remove unused converted_buchstaben

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@ Diese Datei enthält eine Übersicht offener und bereits umgesetzter Aufgaben f�
 - [ ] Fehler‑ und Speichermonitoring
 - [ ] Code‑Cleanup und Struktur (weniger globale Variablen)
 - [ ] CI aufsetzen, die den Arduino‑Code baut
-- [ ] Unbenutzte Variable `converted_buchstaben` entfernen oder implementieren
 - [ ] Dokumentation für Setup und Troubleshooting erweitern
 
 ## Implementierte Features

--- a/src/config.h
+++ b/src/config.h
@@ -82,8 +82,6 @@ bool wifiConnected = false;
 // **Wochentags-Array**
 const char* daysOfTheWeek[7] = {"Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"};
 
-// **Buchstaben-Datenbank für RAW-Dateien**
-std::map<char, uint8_t*> converted_buchstaben;
 
 // **💾 Einstellungen speichern in EEPROM**
 void saveConfig() {


### PR DESCRIPTION
## Summary
- delete unused variable `converted_buchstaben` from `src/config.h`
- clean up TODO list

## Testing
- `pio run` *(fails: UnknownPackageError could not find 2dom/PxMatrix)*

------
https://chatgpt.com/codex/tasks/task_e_6881cdff6a5c8330967d894ffb5444b8