### PR TITLE
Update PlatformIO dependency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ board = nodemcuv2
 framework = arduino
 monitor_speed = 19200
 lib_deps =
-    2dom/PxMatrix
+    2dom/PxMatrix LED MATRIX library@^1.8.2
     me-no-dev/ESP Async WebServer
     me-no-dev/ESPAsyncTCP
     bblanchon/ArduinoJson


### PR DESCRIPTION
## Summary
- specify PxMatrix LED matrix library with version

## Testing
- `pio run` *(fails: UnknownPackageError for me-no-dev/ESP Async WebServer)*

------
https://chatgpt.com/codex/tasks/task_e_6881d5d673608330b6daa31b5f41171c