### PR TITLE
Add PxMatrix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ See [TODO.md](TODO.md) for the project roadmap.
 Install PlatformIO using `pip install platformio` and ensure the `platformio` command is available in your PATH before running `pio run`.
 
 1. PlatformIO is pre-configured using `platformio.ini` and the sources in `src/`.
-2. Run `pio run` to build the firmware.
-3. Use `pio run -t upload` to flash it to the board.
+2. Install the **PxMatrix** library used by `platformio.ini`:
+   - Online: run `pio lib install 2dom/PxMatrix`.
+   - Offline: clone the [PxMatrix repository](https://github.com/2dom/PxMatrix)
+     and place it inside the `lib/` directory.
+3. Run `pio run` to build the firmware.
+4. Use `pio run -t upload` to flash it to the board.
 
 ## Additional Setup
 


### PR DESCRIPTION
## Summary
- update README to show how to install 2dom/PxMatrix library for PlatformIO

## Testing
- `pio run` *(fails: UnknownPackageError while installing `ESP Async WebServer`)*

------
https://chatgpt.com/codex/tasks/task_e_6881d9bbd5748330b47a813fd5a78e47