### PR TITLE
Fix ESPAsyncWebServer dependency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,7 +5,8 @@ framework = arduino
 monitor_speed = 19200
 lib_deps =
     2dom/PxMatrix LED MATRIX library@^1.8.2
-    me-no-dev/ESP Async WebServer
+    me-no-dev/ESPAsyncWebServer
     me-no-dev/ESPAsyncTCP
     bblanchon/ArduinoJson
     adafruit/RTClib
+    adafruit/Adafruit GFX Library


### PR DESCRIPTION
## Summary
- correct ESPAsyncWebServer library name in `platformio.ini`
- add missing Adafruit GFX library

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6881df387f348330a778c1094a09e2a3