### PR TITLE
Fix wifiDisabled declaration

### DIFF
--- a/src/Firmware.ino
+++ b/src/Firmware.ino
@@ -10,6 +10,8 @@ Ticker display_ticker;
 
 AsyncWebServer server(80);
 
+bool wifiDisabled = false;
+
 void setup() {
   Serial.begin(19200);
   delay(500);

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -5,7 +5,7 @@
 #include "web_manager.h"
 #include <ESP8266WiFi.h>
 
-bool wifiDisabled = false;
+extern bool wifiDisabled;
 extern bool triggerActive; 
 
 


### PR DESCRIPTION
## Summary
- deklariere `wifiDisabled` in `wifi_manager.h` als `extern`
- definiere `wifiDisabled` in `Firmware.ino`
- Baue Firmware erfolgreich via `pio run`

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_6885595587e88330a56b391dae0b5b95