### PR TITLE
Kleinere Vorzeichen-Warnungen behoben

### DIFF
--- a/src/Firmware.ino
+++ b/src/Firmware.ino
@@ -54,7 +54,7 @@ void loop() {
             lastDebugTime = millis();  // **Speichert den Zeitpunkt der letzten Ausgabe**
         }
 
-        if (elapsedTime >= (letter_display_time * 1000)) {
+        if (elapsedTime >= ((unsigned long)letter_display_time * 1000UL)) {
             Serial.println(F("🧹 Anzeigezeit abgelaufen, Buchstabe wird gelöscht!"));
             clearDisplay();
             triggerActive = false;

--- a/src/trigger_handler.h
+++ b/src/trigger_handler.h
@@ -164,7 +164,7 @@ void checkTrigger() {
 void checkAutoDisplay() {
     static unsigned long lastDisplayTime = 0;
 
-    if (autoDisplayMode && millis() - lastDisplayTime > (letter_auto_display_interval * 1000)) {
+    if (autoDisplayMode && (millis() - lastDisplayTime > ((unsigned long)letter_auto_display_interval * 1000UL))) {
         lastDisplayTime = millis();
         Serial.println(F("🕒 Automodus aktiv: Zeige heutigen Buchstaben automatisch!"));
 


### PR DESCRIPTION
## Zusammenfassung
- fixe Vergleichswarnungen in `Firmware.ino` und `trigger_handler.h`
- Build läuft weiterhin erfolgreich mit `platformio`

## Test
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6885659791d883308cd985c99a9d20b4