### PR TITLE
Update timing config types

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -58,11 +58,11 @@ const char availableLetters[] = {
 
 // **Konfiguration für Buchstabenanzeige**
 int display_brightness;           // Standard: 100
-int letter_display_time;           // Standard: 10 Sekunden
-int letter_trigger_delay_1; // Verzögerung für Trigger 1
-int letter_trigger_delay_2; // Verzögerung für Trigger 2
-int letter_trigger_delay_3; // Verzögerung für Trigger 3
-int letter_auto_display_interval; // Standard: 5 Minuten
+unsigned long letter_display_time;           // Standard: 10 Sekunden
+unsigned long letter_trigger_delay_1; // Verzögerung für Trigger 1
+unsigned long letter_trigger_delay_2; // Verzögerung für Trigger 2
+unsigned long letter_trigger_delay_3; // Verzögerung für Trigger 3
+unsigned long letter_auto_display_interval; // Standard: 5 Minuten
 
 // **Modus für Buchstabenanzeige (Auto/Trigger)**
 bool autoDisplayMode;
@@ -184,20 +184,20 @@ void loadConfig() {
         eepromUpdated = true;
     }
 
-    if (letter_trigger_delay_1 < 0 || letter_trigger_delay_1 > 999) {
-      letter_trigger_delay_1 = 180;
-      eepromUpdated = true;
-      }
+    if (letter_trigger_delay_1 > 999) {
+        letter_trigger_delay_1 = 180;
+        eepromUpdated = true;
+    }
 
-    if (letter_trigger_delay_2 < 0 || letter_trigger_delay_2 > 999) {
-      letter_trigger_delay_2 = 180;
-            eepromUpdated = true;
-      }
+    if (letter_trigger_delay_2 > 999) {
+        letter_trigger_delay_2 = 180;
+        eepromUpdated = true;
+    }
 
-    if (letter_trigger_delay_3 < 0 || letter_trigger_delay_3 > 999) {
-      letter_trigger_delay_3 = 180;
-            eepromUpdated = true;
-      }
+    if (letter_trigger_delay_3 > 999) {
+        letter_trigger_delay_3 = 180;
+        eepromUpdated = true;
+    }
 
     if (letter_auto_display_interval < 1 || letter_auto_display_interval > 999) {
         Serial.println("🛑 Ungültiges Automodus-Intervall! Setze Standardwert...");

--- a/src/web_manager.h
+++ b/src/web_manager.h
@@ -7,6 +7,7 @@
 #include <ESPAsyncWebServer.h>
 #include <EEPROM.h>
 #include <ArduinoJson.h>
+#include <stdlib.h>
 
 const char scriptJS[] PROGMEM = R"rawliteral(
     // 🕒 Aktuelle Uhrzeit abrufen
@@ -209,11 +210,11 @@ server.on("/updateWiFi", HTTP_POST, [](AsyncWebServerRequest *request) {
             request->hasParam("auto_interval", true)) {
 
             display_brightness = request->getParam("brightness", true)->value().toInt();
-            letter_display_time = request->getParam("letter_time", true)->value().toInt();
-            letter_trigger_delay_1 = request->getParam("trigger_delay_1", true)->value().toInt();
-            letter_trigger_delay_2 = request->getParam("trigger_delay_2", true)->value().toInt();
-            letter_trigger_delay_3 = request->getParam("trigger_delay_3", true)->value().toInt();
-            letter_auto_display_interval = request->getParam("auto_interval", true)->value().toInt();
+            letter_display_time = strtoul(request->getParam("letter_time", true)->value().c_str(), nullptr, 10);
+            letter_trigger_delay_1 = strtoul(request->getParam("trigger_delay_1", true)->value().c_str(), nullptr, 10);
+            letter_trigger_delay_2 = strtoul(request->getParam("trigger_delay_2", true)->value().c_str(), nullptr, 10);
+            letter_trigger_delay_3 = strtoul(request->getParam("trigger_delay_3", true)->value().c_str(), nullptr, 10);
+            letter_auto_display_interval = strtoul(request->getParam("auto_interval", true)->value().c_str(), nullptr, 10);
 
             String autoModeValue = request->hasParam("auto_mode", true) ? request->getParam("auto_mode", true)->value() : "off";
             autoDisplayMode = (autoModeValue == "on");


### PR DESCRIPTION
## Summary
- nutze `unsigned long` für Zeitvariablen in `config.h`
- passe Grenzprüfungen in `loadConfig()` an
- parse numerische Parameter im Webserver mit `strtoul`

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_6885672119188330a4d1d230113e13dd