### PR TITLE
Entferne doppelte Serielle Triggerabfrage

### DIFF
--- a/src/Firmware.ino
+++ b/src/Firmware.ino
@@ -65,13 +65,4 @@ void loop() {
     checkTrigger();
     checkAutoDisplay();
 
-    if (Serial.available() > 0) {
-        char receivedChar = Serial.read();
-        if (receivedChar == '1' || receivedChar == '2' || receivedChar == '3') {
-            handleTrigger(receivedChar, false);
-        } else {
-            Serial.print(F("❌ Falscher Trigger empfangen: "));
-            Serial.println(receivedChar);
-        }
-    }
 }


### PR DESCRIPTION
## Zusammenfassung
- aufräumen der Firmware-Hauptschleife
- doppelte Triggerauswertung nach `checkTrigger()` entfernt

## Testanweisungen
- `pip install platformio`
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_688567372afc83309fb66c6f22976640