### PR TITLE
Fix alreadyCleared linkage

### DIFF
--- a/src/Firmware.ino
+++ b/src/Firmware.ino
@@ -11,6 +11,7 @@ Ticker display_ticker;
 AsyncWebServer server(80);
 
 bool wifiDisabled = false;
+bool alreadyCleared = false;
 
 void setup() {
   Serial.begin(19200);

--- a/src/trigger_handler.h
+++ b/src/trigger_handler.h
@@ -4,7 +4,7 @@
 #include "config.h"
 #include "letters.h"
 
-  static bool alreadyCleared;
+extern bool alreadyCleared;
 
 void clearDisplay() {
     


### PR DESCRIPTION
## Summary
- declare `alreadyCleared` as external symbol
- define `alreadyCleared` in `Firmware.ino`

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_688567478bac833088f5689888949977