### PR TITLE
Use ip-based Wi-Fi setup for bootlocal

### DIFF
--- a/Märchenmanager/usr/local/bin/bootlocal.sh
+++ b/Märchenmanager/usr/local/bin/bootlocal.sh
@@ -1,14 +1,50 @@
 #!/bin/bash
-# Initialisiere WLAN-Interface
-rfkill unblock wifi
-WIFI_IFACE=$(iw dev | awk '$1=="Interface"{print $2}' | head -n1)
-[ -z "$WIFI_IFACE" ] && WIFI_IFACE=wlan0
-ip link set $WIFI_IFACE down
-ip addr flush dev $WIFI_IFACE
-ip addr add 192.168.10.1/24 dev $WIFI_IFACE
-ip link set $WIFI_IFACE up
+set -e
 
-# Erstelle Konfigurationsdateien
+PERSIST_ROOT="/mnt/persist"
+PERSIST_USR_LOCAL="${PERSIST_ROOT}/usr_local"
+
+if [ -d "$PERSIST_USR_LOCAL" ]; then
+    echo "♻️ Synchronisiere persistente /usr/local-Dateien..."
+    mkdir -p /usr/local/bin /usr/local/etc
+    cp -a "$PERSIST_USR_LOCAL/." /usr/local/
+fi
+
+rfkill unblock wifi || true
+
+find_wifi_iface() {
+    for iface_path in /sys/class/net/*; do
+        [ -e "$iface_path" ] || continue
+        iface="$(basename "$iface_path")"
+        [ "$iface" = "lo" ] && continue
+        if [ -d "$iface_path/wireless" ]; then
+            echo "$iface"
+            return 0
+        fi
+        if grep -q "^DEVTYPE=wlan$" "$iface_path/uevent" 2>/dev/null; then
+            echo "$iface"
+            return 0
+        fi
+    done
+    return 1
+}
+
+WIFI_IFACE="$(find_wifi_iface || true)"
+if [ -z "$WIFI_IFACE" ]; then
+    WIFI_IFACE="wlan0"
+    echo "⚠️ Konnte WLAN-Interface nicht automatisch erkennen, verwende Standard: $WIFI_IFACE"
+fi
+
+if ! ip link show "$WIFI_IFACE" &>/dev/null; then
+    echo "❌ WLAN-Interface $WIFI_IFACE nicht gefunden."
+    exit 1
+fi
+
+ip link set "$WIFI_IFACE" down || true
+ip addr flush dev "$WIFI_IFACE" || true
+ip addr add 192.168.10.1/24 dev "$WIFI_IFACE"
+ip link set "$WIFI_IFACE" up
+
 cat > /etc/dnsmasq.conf <<EOL
 interface=$WIFI_IFACE
 bind-interfaces
@@ -25,13 +61,10 @@ wpa=2
 wpa_passphrase=MaerchenByLothar
 EOL
 
-# Stelle sicher, dass DHCP-Leases-Verzeichnis existiert
 mkdir -p /var/lib/misc
 touch /var/lib/misc/dnsmasq.leases
 chmod 777 /var/lib/misc/dnsmasq.leases
 
-# Starte systemd-Services
 systemctl restart hostapd
 systemctl restart dnsmasq
-systemctl restart webserver
-
+systemctl restart webserver || true


### PR DESCRIPTION
## Summary
- update the setup-generated bootlocal.sh to rely on iproute utilities and dynamic wireless interface discovery
- mirror the same bootlocal.sh content in /usr/local/bin to keep the persisted script in sync
- restart hostapd, dnsmasq, and webserver from the unified bootlocal script to ensure the access point comes up consistently

## Testing
- bash -n Märchenmanager/root/debian_minimal_setup.sh
- bash -n Märchenmanager/usr/local/bin/bootlocal.sh

------
https://chatgpt.com/codex/tasks/task_e_68f7ba2c7c548330809170b93d8496a9