### PR TITLE
Add provisioning hook for Märchen webserver

### DIFF
--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -36,6 +36,20 @@ Individuelle Nacharbeiten lassen sich als ausführbare Shell-Skripte (Dateiendun
 werden in alphabetischer Reihenfolge mit dem Ziel-Root als einzigem Argument aufgerufen und erben die Umgebungsvariable
 `TARGET_ROOT`.
 
+### Automatische Webserver-Provisionierung
+
+Der Hook [`hooks.d/10-provision-webserver.sh`](hooks.d/10-provision-webserver.sh) kümmert sich nach dem Kopieren der Dateien
+automatisiert um alle Laufzeitabhängigkeiten des Märchen-Managers:
+
+- prüft mittels `dpkg-query`, ob benötigte Debian-Pakete wie `dnsmasq`, `hostapd`, `rfkill`, `x11-xserver-utils`, `python3`
+  (inkl. `python3-venv`) und optionale Firmware-Pakete installiert sind und stößt bei Bedarf ein `apt-get install` an
+- erzeugt das virtuelle Python-Umfeld unter `/usr/local/venv/maerchen` mit `python3 -m venv`, falls es noch nicht existiert
+- installiert fehlende Python-Abhängigkeiten (`flask`, `requests`, `beautifulsoup4`) idempotent via `pip`
+
+Die Provisionierung läuft sowohl bei einer Installation ins aktive Root-Dateisystem (`TARGET_ROOT=/`) als auch bei einem
+gemounteten Ziel (sofern `chroot` verfügbar ist). Dadurch müssen Operator:innen die Abhängigkeiten nicht mehr manuell
+nachinstallieren – der Webserver ist nach Abschluss von `setup.sh` sofort startklar.
+
 ## WLAN / Access Point
 
 Die SSID und das WPA2-Passwort für den öffentlichen Access Point werden zentral in `/etc/usbstick/public_ap.env`

--- a/USBStick-Setup/files/etc/systemd/system/webserver.service
+++ b/USBStick-Setup/files/etc/systemd/system/webserver.service
@@ -3,6 +3,8 @@ Description=Märchen Manager Webserver
 After=network.target
 
 [Service]
+ExecStartPre=/bin/sh -c '[ -x /usr/local/venv/maerchen/bin/python3 ] || { echo "Virtualenv /usr/local/venv/maerchen missing" >&2; exit 1; }'
+ExecStartPre=/bin/sh -c '[ -f /usr/local/bin/webserver.py ] || { echo "Webserver script /usr/local/bin/webserver.py missing" >&2; exit 1; }'
 ExecStart=/usr/local/venv/maerchen/bin/python3 /usr/local/bin/webserver.py
 Restart=always
 RestartSec=5

--- a/USBStick-Setup/hooks.d/10-provision-webserver.sh
+++ b/USBStick-Setup/hooks.d/10-provision-webserver.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+set -euo pipefail
+
+VENV_DIR=""
+
+log() {
+  printf '[provision] %s\n' "$1"
+}
+
+warn() {
+  printf '[provision] ⚠️  %s\n' "$1" >&2
+}
+
+die() {
+  printf '[provision] ❌ %s\n' "$1" >&2
+  exit 1
+}
+
+resolve_target_root() {
+  local arg="${1:-}" env_root="${TARGET_ROOT:-}"
+  if [[ -n "$arg" ]]; then
+    TARGET_ROOT="$arg"
+  elif [[ -n "$env_root" ]]; then
+    TARGET_ROOT="$env_root"
+  else
+    TARGET_ROOT="/"
+  fi
+
+  if [[ -z "$TARGET_ROOT" ]]; then
+    TARGET_ROOT="/"
+  fi
+
+  if [[ "$TARGET_ROOT" != "/" ]]; then
+    TARGET_ROOT="${TARGET_ROOT%/}"
+    [[ -n "$TARGET_ROOT" ]] || TARGET_ROOT="/"
+  fi
+
+  if [[ ! -d "$TARGET_ROOT" ]]; then
+    die "Target root $TARGET_ROOT does not exist"
+  fi
+}
+
+ensure_system_packages() {
+  local -a packages=(
+    python3
+    python3-venv
+    python3-pip
+    dnsmasq
+    hostapd
+    rfkill
+    curl
+    wget
+    xserver-xorg
+    xinit
+    x11-xserver-utils
+    firefox-esr
+    firmware-linux-nonfree
+    firmware-iwlwifi
+    firmware-realtek
+    firmware-misc-nonfree
+    libffi-dev
+    libssl-dev
+    build-essential
+    linux-image-cloud-amd64
+  )
+
+  local admindir="$TARGET_ROOT/var/lib/dpkg"
+  local dpkg_query="dpkg-query"
+  if ! command -v "$dpkg_query" >/dev/null 2>&1; then
+    warn "dpkg-query not available; skipping package checks"
+    return
+  fi
+
+  if [[ ! -d "$admindir" ]]; then
+    if [[ "$TARGET_ROOT" = "/" ]]; then
+      admindir="/var/lib/dpkg"
+    else
+      warn "Package database $admindir missing; skipping package checks"
+      return
+    fi
+  fi
+
+  local -a missing=()
+  local pkg status
+  for pkg in "${packages[@]}"; do
+    if ! status=$("$dpkg_query" --admindir="$admindir" -W -f='${Status}' "$pkg" 2>/dev/null); then
+      missing+=("$pkg")
+      continue
+    fi
+    if [[ "$status" != *"install ok installed"* ]]; then
+      missing+=("$pkg")
+    fi
+  done
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    log "All required APT packages are already installed"
+    return
+  fi
+
+  local apt_cmd
+  if command -v apt-get >/dev/null 2>&1; then
+    apt_cmd="apt-get"
+  elif command -v apt >/dev/null 2>&1; then
+    apt_cmd="apt"
+  else
+    warn "Neither apt-get nor apt available; cannot install packages"
+    return
+  fi
+
+  if [[ "$TARGET_ROOT" = "/" ]]; then
+    log "Installing missing packages: ${missing[*]}"
+    "$apt_cmd" update
+    "$apt_cmd" install -y "${missing[@]}"
+    return
+  fi
+
+  if ! command -v chroot >/dev/null 2>&1; then
+    warn "chroot not available; cannot install packages for target $TARGET_ROOT"
+    return
+  fi
+
+  log "Installing missing packages inside chroot $TARGET_ROOT: ${missing[*]}"
+  chroot "$TARGET_ROOT" "$apt_cmd" update
+  chroot "$TARGET_ROOT" "$apt_cmd" install -y "${missing[@]}"
+}
+
+venv_python_bin() {
+  if [[ -n "$VENV_DIR" && -x "$VENV_DIR/bin/python3" ]]; then
+    printf '%s\n' "$VENV_DIR/bin/python3"
+    return 0
+  fi
+  if [[ -n "$VENV_DIR" && -x "$VENV_DIR/bin/python" ]]; then
+    printf '%s\n' "$VENV_DIR/bin/python"
+    return 0
+  fi
+  return 1
+}
+
+ensure_virtualenv() {
+  local host_python
+  if command -v python3 >/dev/null 2>&1; then
+    host_python="$(command -v python3)"
+  else
+    die "python3 binary not found on the host system"
+  fi
+
+  if [[ -d "$VENV_DIR/bin" ]]; then
+    log "Python virtual environment already present at $VENV_DIR"
+  else
+    log "Creating Python virtual environment at $VENV_DIR"
+    mkdir -p "$VENV_DIR"
+    "$host_python" -m venv "$VENV_DIR"
+  fi
+
+  local venv_python
+  if ! venv_python="$(venv_python_bin)"; then
+    die "Virtual environment at $VENV_DIR is incomplete"
+  fi
+
+  if [[ ! -x "$VENV_DIR/bin/pip" ]]; then
+    log "Ensuring pip is available inside the virtual environment"
+    "$venv_python" -m ensurepip --upgrade
+  fi
+}
+
+install_python_dependencies() {
+  local -a dependencies=(flask requests beautifulsoup4)
+  local -a missing=()
+  local venv_python
+
+  if ! venv_python="$(venv_python_bin)"; then
+    die "Virtual environment at $VENV_DIR is missing a python interpreter"
+  fi
+
+  for dep in "${dependencies[@]}"; do
+    if ! "$venv_python" -m pip show "$dep" >/dev/null 2>&1; then
+      missing+=("$dep")
+    fi
+  done
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    log "Python dependencies already installed inside virtual environment"
+    return
+  fi
+
+  log "Installing Python dependencies: ${missing[*]}"
+  "$venv_python" -m pip install --disable-pip-version-check --no-input "${missing[@]}"
+}
+
+main() {
+  resolve_target_root "$1"
+  VENV_DIR="$TARGET_ROOT/usr/local/venv/maerchen"
+  ensure_system_packages
+  ensure_virtualenv
+  install_python_dependencies
+  log "Provisioning hook completed"
+}
+
+main "${1:-}"


### PR DESCRIPTION
## Summary
- add a post-install hook that provisions system packages and a Python virtualenv for the webserver
- document the automated provisioning flow for operators running setup.sh
- harden the webserver systemd unit with explicit pre-start checks for required assets

## Testing
- Not run (environment lacks shellcheck)


------
https://chatgpt.com/codex/tasks/task_e_68f7cae0b2ac8330ab2eaa3a75601200