### PR TITLE
Update letters header to use std::map

### DIFF
--- a/src/letters.h
+++ b/src/letters.h
@@ -2,9 +2,10 @@
 #define LETTERS_H
 
 #include <Arduino.h>
+#include <map>
 
 // **Buchstaben-Datenbank (Deklaration für externe Nutzung)**
-extern const uint8_t* letterData[128];
+extern std::map<char, const uint8_t*> letterData;
 
 // **Buchstaben A-Z + #**
 const uint8_t letter_SUN[128] PROGMEM = {


### PR DESCRIPTION
## Summary
- include <map> in letters.h so the std::map declaration is available to every translation unit
- change the global letterData declaration to use std::map<char, const uint8_t*>

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f7d85a10c0833081fc838655b15e56