### PR TITLE
Refactor WiFi connection flow and sync NTP time

### DIFF
--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -1,4 +1,5 @@
 #include "wifi_manager.h"
+#include "rtc_manager.h"
 
 // Funktionen aus wifi_manager.h implementiert
 
@@ -61,6 +62,7 @@ void connectWiFi() {
         Serial.println(WiFi.localIP());
         wifiConnected = true;
         drawWiFiSymbol();
+        syncTimeWithNTP();
         setupWebServer();
     } else {
         Serial.println(F("\n⛔ WiFi Timeout! Verbindung fehlgeschlagen. WiFi bleibt aus."));

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -15,37 +15,7 @@ void clearWiFiSymbol();
 void drawWiFiSymbol();
 
 // **🌐 WiFi verbinden**
-void connectWiFi() {
-    Serial.println(F("🌐 Verbinde mit WiFi..."));
-    WiFi.hostname(hostname);
-    WiFi.begin(wifi_ssid, wifi_password);
-
-    unsigned long startAttempt = millis();
-    unsigned long lastDot = startAttempt;
-    while (WiFi.status() != WL_CONNECTED &&
-           (millis() - startAttempt < (wifi_connect_timeout * 1000UL))) {
-        if (millis() - lastDot >= 2000) {
-            Serial.print(".");
-            lastDot = millis();
-        }
-        delay(10);
-    }
-
-    if (WiFi.status() == WL_CONNECTED) {
-        Serial.println(F("\n✅ WiFi verbunden!"));
-        Serial.print(F("IP-Adresse: "));
-        Serial.println(WiFi.localIP());
-        wifiConnected = true;
-        drawWiFiSymbol();
-        syncTimeWithNTP();
-        setupWebServer();
-    } else {
-        Serial.println(F("\n⛔ WiFi Timeout! Verbindung fehlgeschlagen. WiFi bleibt aus."));
-        wifiConnected = false;
-        WiFi.disconnect();
-        WiFi.mode(WIFI_OFF);  
-    }
-}
+void connectWiFi();
 
 // **🔄 WiFi Reconnect**
 void checkWiFi();


### PR DESCRIPTION
## Summary
- remove the inline connectWiFi implementation from the header and keep only its declaration
- update the source implementation to include rtc_manager and trigger syncTimeWithNTP after a successful WiFi connection

## Testing
- `~/.local/bin/pio run`


------
https://chatgpt.com/codex/tasks/task_e_68f7e48e80808330babc0bb33970cde6