### PR TITLE
Add HTTP handler for triggerLetter route

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -254,6 +254,28 @@ void setupWebServer() {
         }
     });
 
+    server.on("/triggerLetter", HTTP_GET, [](AsyncWebServerRequest *request) {
+        if (triggerActive) {
+            request->send(409, "text/plain", "❌ Fehler: Bereits aktiver Buchstabe verhindert neuen Trigger!");
+            return;
+        }
+
+        int today = getRTCWeekday();
+        if (today < 0 || today >= 7) {
+            request->send(500, "text/plain", "❌ Fehler: Ungültiger Wochentag vom RTC-Modul!");
+            return;
+        }
+
+        char todayLetter = dailyLetters[today];
+        if (todayLetter != '*' && letterData.find(todayLetter) == letterData.end()) {
+            request->send(500, "text/plain", "❌ Fehler: Kein Muster für den heutigen Buchstaben vorhanden!");
+            return;
+        }
+
+        request->send(200, "text/plain", "✅ Buchstaben-Trigger gestartet!");
+        handleTrigger('1', false);
+    });
+
     server.on("/getTime", HTTP_GET, [](AsyncWebServerRequest *request) {
         String currentTime = getRTCTime();
         request->send(200, "text/plain", currentTime);


### PR DESCRIPTION
## Summary
- add an AsyncWebServer GET handler for `/triggerLetter` to trigger the daily letter from the web UI
- return descriptive error responses when the trigger cannot be executed

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f7f2ce8a1883309cee038fb331d5a1