### PR TITLE
Prevent WiFi shutdown when triggering letters via web UI

### DIFF
--- a/src/trigger_handler.cpp
+++ b/src/trigger_handler.cpp
@@ -93,8 +93,8 @@ void displayLetter(char letter) {
     Serial.println(F(" Sekunden!"));
 }
 
-void handleTrigger(char triggerType, bool isAutoMode) {
-    if (wifiConnected && !isAutoMode) {
+void handleTrigger(char triggerType, bool isAutoMode, bool keepWiFi) {
+    if (wifiConnected && !isAutoMode && !keepWiFi) {
         Serial.println(F("⛔ WiFi wird abgeschaltet wegen Trigger!"));
         WiFi.disconnect();
         wifiConnected = false;

--- a/src/trigger_handler.h
+++ b/src/trigger_handler.h
@@ -11,7 +11,7 @@ void clearDisplay();
 // **Funktion: Buchstaben oder Sonderzeichen anzeigen**
 void displayLetter(char letter);
 
-void handleTrigger(char triggerType, bool isAutoMode = false);
+void handleTrigger(char triggerType, bool isAutoMode = false, bool keepWiFi = false);
 
 void checkTrigger();
 

--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -273,7 +273,7 @@ void setupWebServer() {
         }
 
         request->send(200, "text/plain", "✅ Buchstaben-Trigger gestartet!");
-        handleTrigger('1', false);
+        handleTrigger('1', false, true);
     });
 
     server.on("/getTime", HTTP_GET, [](AsyncWebServerRequest *request) {


### PR DESCRIPTION
## Summary
- extend `handleTrigger` to optionally keep WiFi active during manual triggers
- have the `/triggerLetter` route use the new option so the web server stays reachable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f7ff526624833096ffe1cfdaa5cf01