### PR TITLE
Add multi-trigger letter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RiddleMatrix
 
 Dieses Projekt steht unter der MIT-Lizenz. Siehe [LICENSE](LICENSE) für Details.
-RiddleMatrix ist eine Firmware für den ESP8266, die eine 64x64 RGB-LED-Matrix ansteuert. Für jeden Wochentag kann ein Buchstabe festgelegt werden. Die Buchstaben erscheinen entweder zeitgesteuert oder per RS485-Trigger. Über WLAN lässt sich das Gerät konfigurieren; alle Einstellungen werden im EEPROM gespeichert.
+RiddleMatrix ist eine Firmware für den ESP8266, die eine 64x64 RGB-LED-Matrix ansteuert. Für jeden Wochentag und jede der drei RS485-Triggerleitungen lassen sich individuelle Buchstaben und Farben festlegen. Die Buchstaben erscheinen entweder zeitgesteuert oder per RS485-Trigger. Über WLAN lässt sich das Gerät konfigurieren; alle Einstellungen werden im EEPROM gespeichert.
 
 Siehe [TODO.md](TODO.md) für den Projektfahrplan.
 
@@ -65,6 +65,27 @@ Nach der Einrichtung zeigt die Firmware die Buchstaben automatisch an und kann �
 ## Konfiguration
 
 `config.h` enthält Platzhalter-WLAN-Daten, falls noch nichts im EEPROM gespeichert ist. Echte Zugangsdaten sollten **nicht** ins Repository gelangen. Sie können initial über das EEPROM oder die Konfigurationsseite gesetzt werden. Der Parameter `wifi_connect_timeout` bestimmt, wie lange die Verbindung versucht wird (Standard 30 Sekunden).
+
+### Mehrspuriges Buchstabenraster
+
+Die Tagesbuchstaben werden jetzt dreidimensional abgelegt:
+
+- `dailyLetters[trigger][tag]` speichert den Buchstaben pro Triggerleitung und Wochentag.
+- `dailyLetterColors[trigger][tag]` enthält die passende Farbe als `#RRGGBB`-String.
+
+Trigger-Index `0` entspricht RS485-Trigger 1, Index `1` Trigger 2 usw. Die Weboberfläche unter `/` zeigt die Werte als Matrix an und erlaubt das gleichzeitige Aktualisieren über `/updateAllLetters`.
+
+| Wochentag   | Trigger 1 (`#RRGGBB`) | Trigger 2 (`#RRGGBB`) | Trigger 3 (`#RRGGBB`) |
+|-------------|-----------------------|-----------------------|-----------------------|
+| Sonntag     | A (`#FF0000`)         | H (`#FFFFFF`)         | O (`#FFA07A`)         |
+| Montag      | B (`#00FF00`)         | I (`#FFD700`)         | P (`#20B2AA`)         |
+| Dienstag    | C (`#0000FF`)         | J (`#ADFF2F`)         | Q (`#87CEFA`)         |
+| Mittwoch    | D (`#FFFF00`)         | K (`#00CED1`)         | R (`#FFE4B5`)         |
+| Donnerstag  | E (`#FF00FF`)         | L (`#9400D3`)         | S (`#DA70D6`)         |
+| Freitag     | F (`#00FFFF`)         | M (`#FF69B4`)         | T (`#90EE90`)         |
+| Samstag     | G (`#FFA500`)         | N (`#1E90FF`)         | U (`#FFDAB9`)         |
+
+Die HTTP-Endpunkte `/displayLetter` und `/triggerLetter` akzeptieren optional den Parameter `trigger=<1-3>` für Tests je Leitung. Wird kein Trigger angegeben, nutzt die Firmware standardmäßig Leitung 1. Ältere EEPROM-Daten mit eindimensionalen Tagesbuchstaben werden beim ersten Start automatisch migriert.
 
 ## USB-Stick-Setup für das Boxen-Ökosystem
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@ Diese Datei enthält eine Übersicht offener und bereits umgesetzter Aufgaben f�
 ## Implementierte Features
 - [x] RS485‑Trigger mit drei einstellbaren Verzögerungen
 - [x] Automatische Buchstabenausgabe in festen Intervallen
+- [x] Mehrspurige Tageskonfiguration (Buchstaben & Farben pro Triggerleitung)
 - [x] Weboberfläche für WLAN‑Daten, Anzeigeparameter und RTC‑Zeit
 - [x] WiFi‑Symbolanzeige und automatisches Abschalten des Webservers bei Verbindungsverlust
 - [x] EEPROM‑Speicherung aller Einstellungen inklusive Farben je Wochentag

--- a/src/trigger_handler.h
+++ b/src/trigger_handler.h
@@ -9,7 +9,7 @@ extern bool alreadyCleared;
 void clearDisplay();
 
 // **Funktion: Buchstaben oder Sonderzeichen anzeigen**
-void displayLetter(char letter);
+void displayLetter(uint8_t triggerIndex, char letter);
 
 void handleTrigger(char triggerType, bool isAutoMode = false);
 

--- a/tests/test_eeprom_layout.py
+++ b/tests/test_eeprom_layout.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _parse_constants() -> dict[str, int]:
+    header = Path("src/config.h").read_text(encoding="utf-8")
+    pattern = re.compile(r"static constexpr [^=]+ ([A-Za-z0-9_]+) = ([^;]+);")
+    sizeof_map = {
+        "int": 4,
+        "unsigned long": 4,
+        "uint8_t": 1,
+    }
+
+    constants: dict[str, int] = {}
+
+    for name, expr in pattern.findall(header):
+        cleaned = expr
+        for key, value in sizeof_map.items():
+            cleaned = cleaned.replace(f"sizeof({key})", str(value))
+
+        # Evaluate simple arithmetic (addition/multiplication) using already parsed constants.
+        value = eval(cleaned, {}, constants)  # noqa: S307 - Ausdruck ist auf bekannte Konstanten beschränkt
+        constants[name] = int(value)
+
+    return constants
+
+
+def test_new_letter_matrix_offsets() -> None:
+    constants = _parse_constants()
+
+    assert constants["NUM_TRIGGERS"] == 3
+    assert constants["NUM_DAYS"] == 7
+    assert constants["COLOR_STRING_LENGTH"] == 8
+
+    letters_end = constants["EEPROM_OFFSET_DAILY_LETTERS"] + constants["NUM_TRIGGERS"] * constants["NUM_DAYS"]
+    assert letters_end <= constants["EEPROM_OFFSET_DAILY_LETTER_COLORS"], "Letter-Block überschneidet sich mit Farben"
+
+    colors_end = constants["EEPROM_OFFSET_DAILY_LETTER_COLORS"] + constants["NUM_TRIGGERS"] * constants["NUM_DAYS"] * constants["COLOR_STRING_LENGTH"]
+    assert colors_end <= constants["EEPROM_OFFSET_DISPLAY_BRIGHTNESS"], "Farb-Block überschneidet sich mit Display-Parametern"
+
+
+def test_eeprom_usage_fits_into_memory() -> None:
+    constants = _parse_constants()
+
+    eeprom_size = 512
+    wifi_connect_end = constants["EEPROM_OFFSET_WIFI_CONNECT_TIMEOUT"] + 4  # sizeof(int)
+    version_end = constants["EEPROM_OFFSET_CONFIG_VERSION"] + 2  # uint16_t
+
+    assert wifi_connect_end <= eeprom_size
+    assert version_end <= eeprom_size
+    assert constants["EEPROM_CONFIG_VERSION"] >= 2

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -6,6 +6,11 @@ from pathlib import Path
 
 import pytest
 
+try:  # pragma: no cover - optional Abhängigkeit
+    import flask  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    pytest.skip("Flask nicht installiert – Webserver-Tests werden übersprungen", allow_module_level=True)
+
 
 def _load_webserver(tmp_path):
     module_name = "webserver_for_tests"


### PR DESCRIPTION
## Summary
- expand the configuration layout to store letters and colors for all three trigger lines with EEPROM migration
- update trigger handling and the web interface to address trigger-specific previews, delays, and endpoints
- refresh the documentation and add regression tests for the new layout while guarding web tests when Flask is absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f80185cc448330b4f42a485f99941a