### PR TITLE
Add support for multiple daily triggers per box

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -3,6 +3,10 @@ from flask import Flask, jsonify, request
 from bs4 import BeautifulSoup
 import os, json, subprocess, requests
 
+DAYS = ["mo", "di", "mi", "do", "fr", "sa", "so"]
+TRIGGER_SLOTS = 3
+DEFAULT_COLOR = "#ffffff"
+
 app = Flask(__name__)
 LEASE_FILE = "/var/lib/misc/dnsmasq.leases"
 CONFIG_FILE = "/mnt/persist/boxen_config/boxen_config.json"
@@ -14,11 +18,154 @@ if not os.path.exists(CONFIG_FILE):
 
 def load_config():
     with open(CONFIG_FILE, "r") as f:
-        return json.load(f)
+        data = json.load(f)
+    if migrate_config(data):
+        save_config(data)
+    return data
 
 def save_config(data):
     with open(CONFIG_FILE, "w") as f:
         json.dump(data, f, indent=4)
+
+
+def _normalize_letter_list(values, legacy_value=None):
+    normalized = ["" for _ in range(TRIGGER_SLOTS)]
+    if isinstance(values, list):
+        for idx in range(min(TRIGGER_SLOTS, len(values))):
+            val = values[idx]
+            if isinstance(val, str):
+                normalized[idx] = val
+            elif val is not None:
+                normalized[idx] = str(val)
+    elif isinstance(values, dict):
+        for key, val in values.items():
+            if str(key).isdigit():
+                idx = int(str(key))
+                if 0 <= idx < TRIGGER_SLOTS:
+                    if isinstance(val, str):
+                        normalized[idx] = val
+                    elif val is not None:
+                        normalized[idx] = str(val)
+    elif isinstance(values, str):
+        normalized[0] = values
+    elif values is not None:
+        normalized[0] = str(values)
+
+    if isinstance(legacy_value, str) and not normalized[0]:
+        normalized[0] = legacy_value
+    return normalized
+
+
+def _normalize_color_list(values, legacy_value=None):
+    normalized = [DEFAULT_COLOR for _ in range(TRIGGER_SLOTS)]
+    if isinstance(values, list):
+        for idx in range(min(TRIGGER_SLOTS, len(values))):
+            val = values[idx]
+            if isinstance(val, str) and val:
+                normalized[idx] = val
+    elif isinstance(values, dict):
+        for key, val in values.items():
+            if str(key).isdigit():
+                idx = int(str(key))
+                if 0 <= idx < TRIGGER_SLOTS and isinstance(val, str) and val:
+                    normalized[idx] = val
+    elif isinstance(values, str) and values:
+        normalized[0] = values
+
+    if isinstance(legacy_value, str) and (not normalized[0] or normalized[0] == DEFAULT_COLOR):
+        normalized[0] = legacy_value
+    return normalized
+
+
+def ensure_box_structure(box, remove_legacy=False):
+    changed = False
+    if not isinstance(box, dict):
+        return True
+
+    if "letters" not in box or not isinstance(box["letters"], dict):
+        box["letters"] = {}
+        changed = True
+    if "colors" not in box or not isinstance(box["colors"], dict):
+        box["colors"] = {}
+        changed = True
+
+    for day_index, day in enumerate(DAYS):
+        letters = box["letters"].get(day)
+        legacy_letter = box.get(day)
+        normalized_letters = _normalize_letter_list(letters, legacy_letter)
+        if box["letters"].get(day) != normalized_letters:
+            box["letters"][day] = normalized_letters
+            changed = True
+
+        colors = box["colors"].get(day)
+        legacy_color = box.get(f"color_{day}")
+        normalized_colors = _normalize_color_list(colors, legacy_color)
+        if box["colors"].get(day) != normalized_colors:
+            box["colors"][day] = normalized_colors
+            changed = True
+
+        if remove_legacy:
+            if day in box:
+                del box[day]
+                changed = True
+            legacy_color_key = f"color_{day}"
+            if legacy_color_key in box:
+                del box[legacy_color_key]
+                changed = True
+
+    return changed
+
+
+def migrate_config(data):
+    changed = False
+    if not isinstance(data, dict):
+        return False
+
+    if "boxen" not in data or not isinstance(data["boxen"], dict):
+        data["boxen"] = {}
+        changed = True
+    if "boxOrder" not in data or not isinstance(data["boxOrder"], list):
+        data["boxOrder"] = []
+        changed = True
+
+    for box in data["boxen"].values():
+        if ensure_box_structure(box, remove_legacy=True):
+            changed = True
+
+    return changed
+
+
+def extract_box_state_from_soup(soup):
+    letters = {day: ["" for _ in range(TRIGGER_SLOTS)] for day in DAYS}
+    colors = {day: [DEFAULT_COLOR for _ in range(TRIGGER_SLOTS)] for day in DAYS}
+
+    for day_index, day in enumerate(DAYS):
+        for slot in range(TRIGGER_SLOTS):
+            select = soup.find("select", {"name": f"letter{day_index}_{slot}"})
+            if select is None and slot == 0:
+                select = soup.find("select", {"name": f"letter{day_index}"})
+
+            value = ""
+            if select:
+                selected = select.find("option", selected=True)
+                if selected and selected.get("value") is not None:
+                    value = selected.get("value", "")
+                else:
+                    first_option = select.find("option")
+                    if first_option and first_option.get("value") is not None:
+                        value = first_option.get("value", "")
+            letters[day][slot] = value or ""
+
+            color_input = soup.find("input", {"name": f"color{day_index}_{slot}"})
+            if color_input is None and slot == 0:
+                color_input = soup.find("input", {"name": f"color{day_index}"})
+
+            color_value = DEFAULT_COLOR
+            if color_input and color_input.has_attr("value") and color_input["value"]:
+                color_value = color_input["value"]
+            colors[day][slot] = color_value
+
+    return letters, colors
 
 def get_connected_devices():
     devices = []
@@ -81,8 +228,15 @@ def get_hostname_from_web(ip):
 def learn_box(ip, identifier):
     config = load_config()
     if identifier in config["boxen"]:
-        config["boxen"][identifier]["ip"] = ip
-        save_config(config)
+        box = config["boxen"][identifier]
+        changed = False
+        if box.get("ip") != ip:
+            box["ip"] = ip
+            changed = True
+        if ensure_box_structure(box, remove_legacy=True):
+            changed = True
+        if changed:
+            save_config(config)
         return
 
     try:
@@ -90,24 +244,18 @@ def learn_box(ip, identifier):
         if not r.ok:
             return
         soup = BeautifulSoup(r.text, "html.parser")
-        box = {"ip": ip}
-        wochentage = ["mo", "di", "mi", "do", "fr", "sa", "so"]
-        for i, tag in enumerate(wochentage):
-            letter = soup.find("select", {"name": f"letter{i}"})
-            if letter:
-                selected = letter.find("option", selected=True)
-                if not selected:
-                    selected = letter.find("option")
-                if selected:
-                    box[tag] = selected.get("value", "")
-            color = soup.find("input", {"name": f"color{i}"})
-            if color and color.has_attr("value"):
-                box[f"color_{tag}"] = color["value"]
+        letters, colors = extract_box_state_from_soup(soup)
+        box = {
+            "ip": ip,
+            "letters": letters,
+            "colors": colors,
+        }
+        ensure_box_structure(box, remove_legacy=True)
         config["boxen"][identifier] = box
         if identifier not in config["boxOrder"]:
             config["boxOrder"].append(identifier)
         save_config(config)
-    except:
+    except Exception:
         pass
 
 @app.route("/")
@@ -123,16 +271,78 @@ def devices():
 
 @app.route("/update_box", methods=["POST"])
 def update_box():
-    data = request.json
+    data = request.json or {}
     hostname = data.get("hostname")
-    if hostname:
-        config = load_config()
-        if hostname not in config["boxen"]:
-            config["boxen"][hostname] = {}
-        config["boxen"][hostname].update(data)
+    if not hostname:
+        return jsonify({"status": "error"}), 400
+
+    config = load_config()
+    box = config["boxen"].setdefault(hostname, {"ip": "0.0.0.0"})
+    changed = ensure_box_structure(box, remove_legacy=True)
+
+    updated = False
+
+    if "ip" in data and isinstance(data.get("ip"), str):
+        if box.get("ip") != data["ip"]:
+            box["ip"] = data["ip"]
+            updated = True
+
+    letters_payload = data.get("letters")
+    if isinstance(letters_payload, dict):
+        for day, values in letters_payload.items():
+            if day in DAYS:
+                normalized = _normalize_letter_list(values)
+                if box["letters"].get(day) != normalized:
+                    box["letters"][day] = normalized
+                    updated = True
+
+    for day in DAYS:
+        legacy_letter_value = data.get(day)
+        if isinstance(legacy_letter_value, str):
+            normalized = _normalize_letter_list([legacy_letter_value])
+            if box["letters"].get(day) != normalized:
+                box["letters"][day] = normalized
+                updated = True
+
+    colors_payload = data.get("colors")
+    if isinstance(colors_payload, dict):
+        for day, values in colors_payload.items():
+            if day in DAYS:
+                normalized = _normalize_color_list(values)
+                if box["colors"].get(day) != normalized:
+                    box["colors"][day] = normalized
+                    updated = True
+
+    for day in DAYS:
+        legacy_color_value = data.get(f"color_{day}")
+        if isinstance(legacy_color_value, str):
+            normalized = _normalize_color_list([legacy_color_value])
+            if box["colors"].get(day) != normalized:
+                box["colors"][day] = normalized
+                updated = True
+
+    day = data.get("day")
+    trigger_index = data.get("triggerIndex")
+    try:
+        trigger_index = int(trigger_index)
+    except (TypeError, ValueError):
+        trigger_index = None
+
+    if day in DAYS and isinstance(trigger_index, int) and 0 <= trigger_index < TRIGGER_SLOTS:
+        if "letter" in data and isinstance(data.get("letter"), str):
+            letter_value = data["letter"]
+            if box["letters"][day][trigger_index] != letter_value:
+                box["letters"][day][trigger_index] = letter_value
+                updated = True
+        if "color" in data and isinstance(data.get("color"), str):
+            color_value = data["color"] or DEFAULT_COLOR
+            if box["colors"][day][trigger_index] != color_value:
+                box["colors"][day][trigger_index] = color_value
+                updated = True
+
+    if changed or updated:
         save_config(config)
-        return jsonify({"status": "success"})
-    return jsonify({"status": "error"}), 400
+    return jsonify({"status": "success"})
 
 @app.route("/remove_box", methods=["POST"])
 def remove_box():
@@ -169,7 +379,14 @@ def reload_all():
 def transfer_box():
     hostname = request.args.get("hostname")
     config = load_config()
-    box = config["boxen"].get(hostname, {})
+    box = config["boxen"].get(hostname)
+    if not box:
+        return jsonify({"status": "❌ Box unbekannt"})
+
+    changed = ensure_box_structure(box, remove_legacy=True)
+    if changed:
+        save_config(config)
+
     ip = box.get("ip")
     if not ip:
         return jsonify({"status": "❌ IP unbekannt"})
@@ -182,36 +399,26 @@ def transfer_box():
         return jsonify({"status": "❌ Box nicht erreichbar"})
 
     soup = BeautifulSoup(r.text, "html.parser")
-    match = True
-    tags = ["mo", "di", "mi", "do", "fr", "sa", "so"]
-    for i, tag in enumerate(tags):
-        select = soup.find("select", {"name": f"letter{i}"})
-        current_letter = ""
-        if select:
-            selected = select.find("option", selected=True)
-            if selected and selected.get("value"):
-                current_letter = selected["value"]
-        if current_letter != box.get(tag, ""):
-            match = False
-        color_input = soup.find("input", {"name": f"color{i}"})
-        current_color = "#ffffff"
-        if color_input and color_input.get("value"):
-            current_color = color_input["value"]
-        if current_color != box.get(f"color_{tag}", "#ffffff"):
-            match = False
+    remote_letters, remote_colors = extract_box_state_from_soup(soup)
 
-    if match:
+    stored_letters = {day: list(box["letters"][day]) for day in DAYS}
+    stored_colors = {day: list(box["colors"][day]) for day in DAYS}
+
+    if remote_letters == stored_letters and remote_colors == stored_colors:
         return jsonify({"status": "⏭️ Bereits aktuell"})
 
-    payload = {f"letter{i}": box.get(tag, "") for i, tag in enumerate(tags)}
-    payload.update({f"color{i}": box.get(f"color_{tag}", "#ffffff") for i, tag in enumerate(tags)})
+    payload = {
+        "letters": stored_letters,
+        "colors": stored_colors,
+    }
+
     try:
-        r = requests.post(f"http://{ip}/updateAllLetters", data=payload, timeout=3)
+        r = requests.post(f"http://{ip}/updateAllLetters", json=payload, timeout=3)
     except requests.RequestException:
         return jsonify({"status": "❌ Fehler bei Übertragung"})
     if not r.ok:
         return jsonify({"status": "❌ Fehler bei Übertragung"})
-    
+
     return jsonify({"status": "✅ Übertragen"})
 
 @app.route("/shutdown", methods=["POST"])

--- a/USBStick-Setup/files/usr/local/etc/index.html
+++ b/USBStick-Setup/files/usr/local/etc/index.html
@@ -70,10 +70,19 @@
       display: flex; gap: 8px; justify-content: space-between; flex-wrap: wrap;
     }
     .weekday-col {
-      display: flex; flex-direction: column; align-items: center; min-width: 80px;
+      display: flex; flex-direction: column; align-items: stretch; min-width: 120px; gap: 6px;
     }
     .weekday-col select, .weekday-col input[type="color"], .weekday-col input[type="text"] {
       margin-top: 4px; width: 100%; box-sizing: border-box;
+    }
+    .trigger-container {
+      display: flex; flex-direction: column; gap: 6px; width: 100%;
+    }
+    .trigger-entry {
+      display: flex; flex-direction: column; gap: 4px; background: #f9f9f9; padding: 4px; border-radius: 4px;
+    }
+    .trigger-entry span {
+      font-size: 12px; font-weight: bold;
     }
     .word-input {
       margin-bottom: 10px; padding: 5px; width: 100%; max-width: 300px;
@@ -81,6 +90,9 @@
     }
     .word-input.pending { border: 2px solid red; }
     .word-input.saved { border: 2px solid green; }
+    .word-trigger-selector {
+      display: flex; align-items: center; gap: 8px; margin-bottom: 10px; flex-wrap: wrap;
+    }
     .action-buttons button {
       padding: 10px; margin-right: 10px; font-size: 14px;
     }
@@ -111,10 +123,33 @@ let transferQueue = {};
 let transferring = false;
 let statusArea;
 let boxOrder = [];
+const days = ["mo", "di", "mi", "do", "fr", "sa", "so"];
+const dayNames = ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
+const triggersPerDay = 3;
+const defaultColor = "#ffffff";
+const letterLabels = {"*": "Sun+Rad", "#": "Sun", "~": "WIFI", "&": "Rad", "?": "Riddler"};
+const letterOptions = "ABCDEFGHIJKLMNOPQRSTUVWXYZ*#~&?".split("");
+let currentWordTrigger = 0;
 
 function init() {
   fetchDevices();
   setInterval(fetchDevices, 1000); // Prüfe alle 1 Sekunde
+}
+
+function normalizeBox(box) {
+  box = box || {};
+  box.letters = box.letters || {};
+  box.colors = box.colors || {};
+  days.forEach(day => {
+    const letters = Array.isArray(box.letters[day]) ? box.letters[day].slice(0, triggersPerDay) : [];
+    while (letters.length < triggersPerDay) letters.push("");
+    box.letters[day] = letters;
+
+    const colors = Array.isArray(box.colors[day]) ? box.colors[day].slice(0, triggersPerDay) : [];
+    while (colors.length < triggersPerDay) colors.push(defaultColor);
+    box.colors[day] = colors;
+  });
+  return box;
 }
 
 async function fetchDevices() {
@@ -125,13 +160,18 @@ async function fetchDevices() {
     const newConnectedBoxes = data.connected || [];
     const newBoxOrder = data.boxOrder || Object.keys(newKnownBoxes);
 
+    const normalizedIncoming = {};
+    Object.entries(newKnownBoxes).forEach(([hostname, box]) => {
+      normalizedIncoming[hostname] = normalizeBox(JSON.parse(JSON.stringify(box)));
+    });
+
     // Prüfe auf Änderungen
     const hasChanges =
-      JSON.stringify(knownBoxes) !== JSON.stringify(newKnownBoxes) ||
+      JSON.stringify(knownBoxes) !== JSON.stringify(normalizedIncoming) ||
       JSON.stringify(connectedBoxes) !== JSON.stringify(newConnectedBoxes) ||
       JSON.stringify(boxOrder) !== JSON.stringify(newBoxOrder);
 
-    knownBoxes = newKnownBoxes;
+    knownBoxes = normalizedIncoming;
     connectedBoxes = newConnectedBoxes;
     boxOrder = newBoxOrder;
 
@@ -169,41 +209,61 @@ function shutdown() {
 }
 
 function showSetup() {
-  const letterLabels = {"*": "Sun+Rad", "#": "Sun", "~": "WIFI", "&": "Rad", "?": "Riddler"};
   let html = '<h2>Boxen verwalten</h2>';
-  const days = ["mo", "di", "mi", "do", "fr", "sa", "so"];
-  const dayNames = ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
   const maxLength = boxOrder.length;
 
-  html += '<div class="box-card"><h3>Wörter für Wochentage</h3><div class="weekday-row">';
-  for (let i = 0; i < 7; i++) {
-    const currentWord = boxOrder.map(hostname => knownBoxes[hostname]?.[days[i]] || "").join("");
+  html += '<div class="box-card"><h3>Wörter für Wochentage</h3>';
+  html += '<div class="word-trigger-selector">';
+  html += '<label for="wordTriggerSelect">Trigger-Spalte:</label>';
+  html += '<select id="wordTriggerSelect" onchange="changeWordTrigger(parseInt(this.value, 10))">';
+  for (let trigger = 0; trigger < triggersPerDay; trigger++) {
+    const selected = trigger === currentWordTrigger ? "selected" : "";
+    html += `<option value="${trigger}" ${selected}>Trigger ${trigger + 1}</option>`;
+  }
+  html += '</select></div>';
+
+  html += '<div class="weekday-row">';
+  for (let i = 0; i < days.length; i++) {
+    const currentWord = boxOrder.map(hostname => {
+      const letters = knownBoxes[hostname]?.letters?.[days[i]] || [];
+      return letters[currentWordTrigger] || "";
+    }).join("");
     html += `
       <div class="weekday-col">
         <label>${dayNames[i]}</label>
-        <input type="text" class="word-input" placeholder="Wort eingeben (max ${maxLength} Zeichen)" 
-          value="${currentWord}" onchange="updateWord('${days[i]}', this.value, ${maxLength}, this)" 
+        <input type="text" class="word-input" placeholder="Wort eingeben (max ${maxLength} Zeichen)"
+          value="${currentWord}" onchange="updateWord('${days[i]}', this.value, ${maxLength}, this)"
           onkeydown="handleKeydown(event, '${days[i]}', this.value, ${maxLength}, this)">
       </div>`;
   }
   html += '</div></div>';
 
   boxOrder.forEach((hostname, index) => {
-    const box = knownBoxes[hostname] || {};
+    const box = normalizeBox(knownBoxes[hostname] || {});
     html += `<div class="box-card"><h3><span class="box-order">${index + 1}</span>${hostname}</h3><div class="weekday-row">`;
-    for (let i = 0; i < 7; i++) {
-      const letter = box[days[i]] || "";
-      const color = box["color_" + days[i]] || "#ffffff";
-      const letterOptions = "ABCDEFGHIJKLMNOPQRSTUVWXYZ*#~&?".split("").map(c =>
-        `<option value="${c}" ${c === letter ? "selected" : ""}>${letterLabels[c] || c}</option>`).join("");
-
+    for (let i = 0; i < days.length; i++) {
+      const letters = box.letters?.[days[i]] || [];
+      const colors = box.colors?.[days[i]] || [];
       html += `
         <div class="weekday-col">
           <label>${dayNames[i]}</label>
-          <select onchange="saveField('${hostname}', '${days[i]}', this.value)" onfocus="this.size='7'" onblur="this.size='1'" onclick="event.stopPropagation();">
-            ${letterOptions}
-          </select>
-          <input type="color" value="${color}" onchange="saveField('${hostname}', 'color_${days[i]}', this.value)">
+          <div class="trigger-container">`;
+      for (let trigger = 0; trigger < triggersPerDay; trigger++) {
+        const letter = letters[trigger] || "";
+        const color = colors[trigger] || defaultColor;
+        const letterOptionsHtml = letterOptions.map(c =>
+          `<option value="${c}" ${c === letter ? "selected" : ""}>${letterLabels[c] || c}</option>`).join("");
+        html += `
+            <div class="trigger-entry">
+              <span>Trigger ${trigger + 1}</span>
+              <select onchange="saveField('${hostname}', '${days[i]}', ${trigger}, this.value, 'letter')" onfocus="this.size='7'" onblur="this.size='1'" onclick="event.stopPropagation();">
+                ${letterOptionsHtml}
+              </select>
+              <input type="color" value="${color}" onchange="saveField('${hostname}', '${days[i]}', ${trigger}, this.value, 'color')">
+            </div>`;
+      }
+      html += `
+          </div>
         </div>`;
     }
     html += `</div>
@@ -238,19 +298,33 @@ function updateWord(day, word, maxLength, inputElement) {
   for (let i = 0; i < boxOrder.length; i++) {
     const letter = i < word.length ? word[i] : "*";
     knownBoxes[boxOrder[i]] = knownBoxes[boxOrder[i]] || {};
-    knownBoxes[boxOrder[i]][day] = letter;
-    saveField(boxOrder[i], day, letter, false, inputElement);
+    saveField(boxOrder[i], day, currentWordTrigger, letter, 'letter', false, inputElement);
   }
   showSetup();
 }
 
-function saveField(hostname, key, value, updateUI = true, inputElement = null) {
-  knownBoxes[hostname] = knownBoxes[hostname] || {};
-  knownBoxes[hostname][key] = value;
+function saveField(hostname, day, triggerIndex, value, fieldType = 'letter', updateUI = true, inputElement = null) {
+  knownBoxes[hostname] = normalizeBox(knownBoxes[hostname] || {});
+  const slotIndex = Number(triggerIndex);
+  if (fieldType === 'letter') {
+    knownBoxes[hostname].letters[day][slotIndex] = value;
+  } else {
+    const colorValue = value || defaultColor;
+    knownBoxes[hostname].colors[day][slotIndex] = colorValue;
+    value = colorValue;
+  }
+
+  const payload = { hostname, day, triggerIndex: slotIndex };
+  if (fieldType === 'letter') {
+    payload.letter = value;
+  } else {
+    payload.color = value;
+  }
+
   fetch("/update_box", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ hostname, [key]: value })
+    body: JSON.stringify(payload)
   }).then(response => {
     if (!response.ok) {
       statusArea.innerHTML = '<div class="statusEntry status">❌ Fehler beim Speichen.</div>';
@@ -269,6 +343,17 @@ function saveField(hostname, key, value, updateUI = true, inputElement = null) {
     statusArea.innerHTML = '<div class="statusEntry status">❌ Fehler beim Speichern.</div>';
     if (inputElement) inputElement.classList.remove("pending");
   });
+}
+
+function changeWordTrigger(newTrigger) {
+  if (!Number.isInteger(newTrigger)) {
+    newTrigger = parseInt(newTrigger, 10);
+  }
+  if (Number.isNaN(newTrigger) || newTrigger < 0 || newTrigger >= triggersPerDay) {
+    return;
+  }
+  currentWordTrigger = newTrigger;
+  showSetup();
 }
 
 function moveBoxUp(hostname) {

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -29,6 +29,12 @@ def _load_webserver(tmp_path):
     return module
 
 
+def _empty_box(module, ip="1.2.3.4"):
+    letters = {day: ["" for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+    colors = {day: [module.DEFAULT_COLOR for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+    return {"ip": ip, "letters": letters, "colors": colors}
+
+
 @pytest.fixture
 def webserver_app(tmp_path):
     module = _load_webserver(tmp_path)
@@ -38,7 +44,7 @@ def webserver_app(tmp_path):
 
 def test_transfer_box_returns_json_on_get_error(webserver_app, monkeypatch):
     module, client = webserver_app
-    module.save_config({"boxen": {"TestBox": {"ip": "1.2.3.4"}}, "boxOrder": []})
+    module.save_config({"boxen": {"TestBox": _empty_box(module)}, "boxOrder": []})
 
     def raise_request(*args, **kwargs):
         raise module.requests.RequestException("boom")
@@ -52,7 +58,9 @@ def test_transfer_box_returns_json_on_get_error(webserver_app, monkeypatch):
 
 def test_transfer_box_returns_json_on_post_error(webserver_app, monkeypatch):
     module, client = webserver_app
-    module.save_config({"boxen": {"TestBox": {"ip": "1.2.3.4", "mo": "A"}}, "boxOrder": []})
+    box = _empty_box(module)
+    box["letters"]["mo"][0] = "A"
+    module.save_config({"boxen": {"TestBox": box}, "boxOrder": []})
 
     class FakeResponse:
         def __init__(self, text: str, ok: bool = True) -> None:
@@ -69,3 +77,73 @@ def test_transfer_box_returns_json_on_post_error(webserver_app, monkeypatch):
     response = client.get("/transfer_box", query_string={"hostname": "TestBox"})
     assert response.status_code == 200
     assert response.get_json() == {"status": "❌ Fehler bei Übertragung"}
+
+
+def test_update_box_updates_specific_trigger(webserver_app):
+    module, client = webserver_app
+    module.save_config({"boxen": {"TestBox": _empty_box(module)}, "boxOrder": []})
+
+    response = client.post(
+        "/update_box",
+        json={"hostname": "TestBox", "day": "mo", "triggerIndex": 1, "letter": "B"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "success"}
+
+    config = module.load_config()
+    assert config["boxen"]["TestBox"]["letters"]["mo"][1] == "B"
+
+    response = client.post(
+        "/update_box",
+        json={"hostname": "TestBox", "day": "mo", "triggerIndex": 2, "color": "#123456"},
+    )
+
+    assert response.status_code == 200
+    config = module.load_config()
+    assert config["boxen"]["TestBox"]["colors"]["mo"][2] == "#123456"
+
+
+def test_transfer_box_sends_all_triggers_json(webserver_app, monkeypatch):
+    module, client = webserver_app
+    letters = {day: [f"{day}{idx}" for idx in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+    colors = {day: [f"#0{idx}{idx}{idx}{idx}{idx}"[:7] for idx in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+    module.save_config({"boxen": {"TestBox": {"ip": "1.2.3.4", "letters": letters, "colors": colors}}, "boxOrder": []})
+
+    html_parts = ["<html><body>"]
+    for index, day in enumerate(module.DAYS):
+        for slot in range(module.TRIGGER_SLOTS):
+            html_parts.append(
+                f"<select name='letter{index}_{slot}'><option value='x' selected>x</option></select>"
+            )
+            html_parts.append(
+                f"<input name='color{index}_{slot}' value='{module.DEFAULT_COLOR}'>"
+            )
+    html_parts.append("</body></html>")
+    fake_html = "".join(html_parts)
+
+    class FakeResponse:
+        def __init__(self, text: str, ok: bool = True) -> None:
+            self.text = text
+            self.ok = ok
+
+    monkeypatch.setattr(module.requests, "get", lambda *_, **__: FakeResponse(fake_html, True))
+
+    captured = {}
+
+    def fake_post(url, json=None, timeout=3):
+        captured["url"] = url
+        captured["json"] = json
+
+        class PostResponse:
+            ok = True
+
+        return PostResponse()
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    response = client.get("/transfer_box", query_string={"hostname": "TestBox"})
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "✅ Übertragen"}
+    assert captured["url"].endswith("/updateAllLetters")
+    assert captured["json"] == {"letters": letters, "colors": colors}


### PR DESCRIPTION
## Summary
- extend the browser UI to edit three trigger columns per weekday including color pickers and trigger-based word input
- update the webserver backend to migrate legacy configs, store trigger arrays per day, and push the new JSON payload to /updateAllLetters
- expand the webserver test suite to cover the new data structure and multi-trigger transfer workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f8164e476c83309df95d18e229888e