### PR TITLE
Implementiere Verzögerungsmatrix pro Trigger und Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RiddleMatrix
 
 Dieses Projekt steht unter der MIT-Lizenz. Siehe [LICENSE](LICENSE) für Details.
-RiddleMatrix ist eine Firmware für den ESP8266, die eine 64x64 RGB-LED-Matrix ansteuert. Für jeden Wochentag und jede der drei RS485-Triggerleitungen lassen sich individuelle Buchstaben und Farben festlegen. Die Buchstaben erscheinen entweder zeitgesteuert oder per RS485-Trigger. Über WLAN lässt sich das Gerät konfigurieren; alle Einstellungen werden im EEPROM gespeichert.
+RiddleMatrix ist eine Firmware für den ESP8266, die eine 64x64 RGB-LED-Matrix ansteuert. Für jeden Wochentag und jede der drei RS485-Triggerleitungen lassen sich individuelle Buchstaben, Farben **und Verzögerungszeiten** festlegen. Die Buchstaben erscheinen entweder zeitgesteuert oder per RS485-Trigger. Über WLAN lässt sich das Gerät konfigurieren; alle Einstellungen werden im EEPROM gespeichert.
 
 Siehe [TODO.md](TODO.md) für den Projektfahrplan.
 
@@ -86,6 +86,13 @@ Trigger-Index `0` entspricht RS485-Trigger 1, Index `1` Trigger 2 usw. Die Web
 | Samstag     | G (`#FFA500`)         | N (`#1E90FF`)         | U (`#FFDAB9`)         |
 
 Die HTTP-Endpunkte `/displayLetter` und `/triggerLetter` akzeptieren optional den Parameter `trigger=<1-3>` für Tests je Leitung. Wird kein Trigger angegeben, nutzt die Firmware standardmäßig Leitung 1. Ältere EEPROM-Daten mit eindimensionalen Tagesbuchstaben werden beim ersten Start automatisch migriert.
+
+### Verzögerungsmatrix pro Trigger & Tag
+
+- `letter_trigger_delays[trigger][tag]` verwaltet die Wartezeit (Sekunden) vor der Anzeige.
+- Die Weboberfläche stellt die Werte als Tabelle dar und validiert Eingaben auf ganzzahlige Werte zwischen 0 und 999.
+- Die API `/updateTriggerDelays` akzeptiert ein `FormData`-Payload mit Feldern `delay_<triggerIndex>_<dayIndex>` (Indexbeginn 0). Erfolgreiche Aufrufe speichern Matrix, Buchstaben, Farben und sonstige Parameter gemeinsam im EEPROM (`saveConfig()`).
+- Legacy-Konfigurationen mit drei Verzögerungswerten werden beim Laden gleichmäßig auf alle Wochentage verteilt.
 
 ## USB-Stick-Setup für das Boxen-Ökosystem
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@ Diese Datei enthält eine Übersicht offener und bereits umgesetzter Aufgaben f�
 - [ ] Dokumentation für Setup und Troubleshooting erweitern
 
 ## Implementierte Features
-- [x] RS485‑Trigger mit drei einstellbaren Verzögerungen
+- [x] RS485‑Trigger mit tagesabhängigen Verzögerungsmatrizen
 - [x] Automatische Buchstabenausgabe in festen Intervallen
 - [x] Mehrspurige Tageskonfiguration (Buchstaben & Farben pro Triggerleitung)
 - [x] Weboberfläche für WLAN‑Daten, Anzeigeparameter und RTC‑Zeit

--- a/src/config.h
+++ b/src/config.h
@@ -46,14 +46,13 @@ static constexpr uint16_t EEPROM_OFFSET_DAILY_LETTERS = EEPROM_OFFSET_HOSTNAME +
 static constexpr uint16_t EEPROM_OFFSET_DAILY_LETTER_COLORS = 200; // Historischer Versatz für Rückwärtskompatibilität
 static constexpr uint16_t EEPROM_OFFSET_DISPLAY_BRIGHTNESS = EEPROM_OFFSET_DAILY_LETTER_COLORS + (NUM_TRIGGERS * NUM_DAYS * COLOR_STRING_LENGTH);
 static constexpr uint16_t EEPROM_OFFSET_LETTER_DISPLAY_TIME = EEPROM_OFFSET_DISPLAY_BRIGHTNESS + sizeof(int);
-static constexpr uint16_t EEPROM_OFFSET_TRIGGER_DELAY_1 = EEPROM_OFFSET_LETTER_DISPLAY_TIME + sizeof(unsigned long);
-static constexpr uint16_t EEPROM_OFFSET_TRIGGER_DELAY_2 = EEPROM_OFFSET_TRIGGER_DELAY_1 + sizeof(unsigned long);
-static constexpr uint16_t EEPROM_OFFSET_TRIGGER_DELAY_3 = EEPROM_OFFSET_TRIGGER_DELAY_2 + sizeof(unsigned long);
-static constexpr uint16_t EEPROM_OFFSET_AUTO_INTERVAL = EEPROM_OFFSET_TRIGGER_DELAY_3 + sizeof(unsigned long);
+static constexpr uint16_t EEPROM_OFFSET_TRIGGER_DELAY_MATRIX = EEPROM_OFFSET_LETTER_DISPLAY_TIME + sizeof(unsigned long);
+static constexpr size_t EEPROM_TRIGGER_DELAY_MATRIX_SIZE = NUM_TRIGGERS * NUM_DAYS * sizeof(unsigned long);
+static constexpr uint16_t EEPROM_OFFSET_AUTO_INTERVAL = EEPROM_OFFSET_TRIGGER_DELAY_MATRIX + EEPROM_TRIGGER_DELAY_MATRIX_SIZE;
 static constexpr uint16_t EEPROM_OFFSET_AUTO_MODE = EEPROM_OFFSET_AUTO_INTERVAL + sizeof(unsigned long);
 static constexpr uint16_t EEPROM_OFFSET_WIFI_CONNECT_TIMEOUT = EEPROM_OFFSET_AUTO_MODE + sizeof(uint8_t);
 static constexpr uint16_t EEPROM_OFFSET_CONFIG_VERSION = 400;
-static constexpr uint16_t EEPROM_CONFIG_VERSION = 2;
+static constexpr uint16_t EEPROM_CONFIG_VERSION = 3;
 
 // **Standard-WiFi-Daten (werden bei Erststart gesetzt)**
 extern char wifi_ssid[50];
@@ -81,9 +80,7 @@ const char availableLetters[] = {
 // **Konfiguration für Buchstabenanzeige**
 extern int display_brightness;           // Standard: 100
 extern unsigned long letter_display_time;           // Standard: 10 Sekunden
-extern unsigned long letter_trigger_delay_1; // Verzögerung für Trigger 1
-extern unsigned long letter_trigger_delay_2; // Verzögerung für Trigger 2
-extern unsigned long letter_trigger_delay_3; // Verzögerung für Trigger 3
+extern unsigned long letter_trigger_delays[NUM_TRIGGERS][NUM_DAYS];
 extern unsigned long letter_auto_display_interval; // Standard: 5 Minuten
 
 // **Modus für Buchstabenanzeige (Auto/Trigger)**

--- a/src/trigger_handler.cpp
+++ b/src/trigger_handler.cpp
@@ -127,8 +127,14 @@ void handleTrigger(char triggerType, bool isAutoMode) {
     }
 
     int today = getRTCWeekday();
+    bool validDay = today >= 0 && today < static_cast<int>(NUM_DAYS);
+    size_t delayDayIndex = validDay ? static_cast<size_t>(today) : 0;
 
-    if (today >= 0 && today < static_cast<int>(NUM_DAYS)) {
+    if (!validDay) {
+        Serial.println(F("⚠️ Ungültiger Wochentag! Nutze Fallback-Index 0 für Verzögerungen."));
+    }
+
+    if (validDay) {
         char letter = dailyLetters[triggerIndex][today];
         Serial.print(F("📅 Heute ist "));
         Serial.print(daysOfTheWeek[today]);
@@ -139,18 +145,11 @@ void handleTrigger(char triggerType, bool isAutoMode) {
 
         unsigned long delayTime = 0;
         if (!isAutoMode) {
-            if (triggerIndex == 0) {
-                delayTime = letter_trigger_delay_1;
-            } else if (triggerIndex == 1) {
-                delayTime = letter_trigger_delay_2;
-            } else {
-                delayTime = letter_trigger_delay_3;
-            }
-
+            delayTime = letter_trigger_delays[triggerIndex][delayDayIndex];
             Serial.print(F("⏳ Warte auf Trigger-Verzögerung: "));
             Serial.print(delayTime);
             Serial.println(F(" Sekunden..."));
-            delay(delayTime * 1000);
+            delay(delayTime * 1000UL);
         }
 
         displayLetter(triggerIndex, letter);
@@ -158,7 +157,7 @@ void handleTrigger(char triggerType, bool isAutoMode) {
         alreadyCleared = false;
 
     } else {
-        Serial.println(F("⚠️ Ungültiger Wochentag!"));
+        Serial.println(F("⚠️ Ungültiger Wochentag! Anzeige wird übersprungen."));
     }
 }
 

--- a/tests/test_eeprom_layout.py
+++ b/tests/test_eeprom_layout.py
@@ -40,6 +40,9 @@ def test_new_letter_matrix_offsets() -> None:
     colors_end = constants["EEPROM_OFFSET_DAILY_LETTER_COLORS"] + constants["NUM_TRIGGERS"] * constants["NUM_DAYS"] * constants["COLOR_STRING_LENGTH"]
     assert colors_end <= constants["EEPROM_OFFSET_DISPLAY_BRIGHTNESS"], "Farb-Block überschneidet sich mit Display-Parametern"
 
+    matrix_end = constants["EEPROM_OFFSET_TRIGGER_DELAY_MATRIX"] + constants["EEPROM_TRIGGER_DELAY_MATRIX_SIZE"]
+    assert matrix_end <= constants["EEPROM_OFFSET_AUTO_INTERVAL"], "Verzögerungsmatrix überschneidet sich mit Auto-Intervall"
+
 
 def test_eeprom_usage_fits_into_memory() -> None:
     constants = _parse_constants()
@@ -50,4 +53,4 @@ def test_eeprom_usage_fits_into_memory() -> None:
 
     assert wifi_connect_end <= eeprom_size
     assert version_end <= eeprom_size
-    assert constants["EEPROM_CONFIG_VERSION"] >= 2
+    assert constants["EEPROM_CONFIG_VERSION"] >= 3


### PR DESCRIPTION
## Zusammenfassung
- erweitere die Konfigurationsstruktur um eine Verzögerungsmatrix `letter_trigger_delays[NUM_TRIGGERS][NUM_DAYS]` inklusive Legacy-Migration und Validierung
- nutze die Matrix in `handleTrigger()` mit Fallback bei ungültigen Tagesindizes und passe die Weboberfläche samt neuer API `/updateTriggerDelays` an
- aktualisiere Dokumentation und Tests, damit das EEPROM-Layout weiterhin in 512 Byte passt und die neue Schema-Version widerspiegelt

## Tests
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68f8607e07c083309c654b875c4295b2