### PR TITLE
Füge Trigger-Verzögerungen für Boxen hinzu

### DIFF
--- a/USBStick-Setup/files/usr/local/etc/index.html
+++ b/USBStick-Setup/files/usr/local/etc/index.html
@@ -72,7 +72,8 @@
     .weekday-col {
       display: flex; flex-direction: column; align-items: stretch; min-width: 120px; gap: 6px;
     }
-    .weekday-col select, .weekday-col input[type="color"], .weekday-col input[type="text"] {
+    .weekday-col select, .weekday-col input[type="color"], .weekday-col input[type="text"],
+    .weekday-col input[type="number"] {
       margin-top: 4px; width: 100%; box-sizing: border-box;
     }
     .trigger-container {
@@ -90,6 +91,14 @@
     }
     .word-input.pending { border: 2px solid red; }
     .word-input.saved { border: 2px solid green; }
+    .delay-input.pending { border: 2px solid red; }
+    .delay-input.saved { border: 2px solid green; }
+    .delay-input-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      font-size: 12px;
+    }
     .word-trigger-selector {
       display: flex; align-items: center; gap: 8px; margin-bottom: 10px; flex-wrap: wrap;
     }
@@ -127,6 +136,7 @@ const days = ["mo", "di", "mi", "do", "fr", "sa", "so"];
 const dayNames = ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
 const triggersPerDay = 3;
 const defaultColor = "#ffffff";
+const defaultDelay = 0;
 const letterLabels = {"*": "Sun+Rad", "#": "Sun", "~": "WIFI", "&": "Rad", "?": "Riddler"};
 const letterOptions = "ABCDEFGHIJKLMNOPQRSTUVWXYZ*#~&?".split("");
 let currentWordTrigger = 0;
@@ -140,6 +150,7 @@ function normalizeBox(box) {
   box = box || {};
   box.letters = box.letters || {};
   box.colors = box.colors || {};
+  box.delays = box.delays || {};
   days.forEach(day => {
     const letters = Array.isArray(box.letters[day]) ? box.letters[day].slice(0, triggersPerDay) : [];
     while (letters.length < triggersPerDay) letters.push("");
@@ -148,6 +159,16 @@ function normalizeBox(box) {
     const colors = Array.isArray(box.colors[day]) ? box.colors[day].slice(0, triggersPerDay) : [];
     while (colors.length < triggersPerDay) colors.push(defaultColor);
     box.colors[day] = colors;
+
+    const delays = Array.isArray(box.delays[day]) ? box.delays[day].slice(0, triggersPerDay) : [];
+    while (delays.length < triggersPerDay) delays.push(defaultDelay);
+    box.delays[day] = delays.map(value => {
+      const numeric = typeof value === "number" ? value : parseFloat(value);
+      if (!Number.isFinite(numeric) || numeric < 0) {
+        return defaultDelay;
+      }
+      return Math.round((numeric + Number.EPSILON) * 1000) / 1000;
+    });
   });
   return box;
 }
@@ -177,8 +198,9 @@ async function fetchDevices() {
 
     renderDeviceList();
     // Nur showSetup() aufrufen, wenn kein Textfeld oder Dropdown-Menü fokussiert ist
-    if (hasChanges && statusArea && !transferring && 
-        !document.activeElement.classList.contains("word-input") && 
+    if (hasChanges && statusArea && !transferring &&
+        !document.activeElement.classList.contains("word-input") &&
+        !document.activeElement.classList.contains("delay-input") &&
         document.activeElement.tagName !== "SELECT") {
       showSetup();
     }
@@ -244,6 +266,7 @@ function showSetup() {
     for (let i = 0; i < days.length; i++) {
       const letters = box.letters?.[days[i]] || [];
       const colors = box.colors?.[days[i]] || [];
+      const delays = box.delays?.[days[i]] || [];
       html += `
         <div class="weekday-col">
           <label>${dayNames[i]}</label>
@@ -251,6 +274,10 @@ function showSetup() {
       for (let trigger = 0; trigger < triggersPerDay; trigger++) {
         const letter = letters[trigger] || "";
         const color = colors[trigger] || defaultColor;
+        const rawDelay = delays[trigger];
+        const parsedDelay = Number(rawDelay);
+        const delayValue = Number.isFinite(parsedDelay) && parsedDelay >= 0 ? parsedDelay : defaultDelay;
+        const delayDisplay = delayValue.toString();
         const letterOptionsHtml = letterOptions.map(c =>
           `<option value="${c}" ${c === letter ? "selected" : ""}>${letterLabels[c] || c}</option>`).join("");
         html += `
@@ -260,6 +287,10 @@ function showSetup() {
                 ${letterOptionsHtml}
               </select>
               <input type="color" value="${color}" onchange="saveField('${hostname}', '${days[i]}', ${trigger}, this.value, 'color')">
+              <div class="delay-input-wrapper">
+                <span>Verzögerung (s)</span>
+                <input type="number" class="delay-input" min="0" step="0.1" value="${delayDisplay}" onchange="saveField('${hostname}', '${days[i]}', ${trigger}, this.value, 'delay', true, this)">
+              </div>
             </div>`;
       }
       html += `
@@ -306,19 +337,32 @@ function updateWord(day, word, maxLength, inputElement) {
 function saveField(hostname, day, triggerIndex, value, fieldType = 'letter', updateUI = true, inputElement = null) {
   knownBoxes[hostname] = normalizeBox(knownBoxes[hostname] || {});
   const slotIndex = Number(triggerIndex);
+  if (inputElement) {
+    inputElement.classList.add('pending');
+  }
   if (fieldType === 'letter') {
     knownBoxes[hostname].letters[day][slotIndex] = value;
-  } else {
+  } else if (fieldType === 'color') {
     const colorValue = value || defaultColor;
     knownBoxes[hostname].colors[day][slotIndex] = colorValue;
     value = colorValue;
+  } else if (fieldType === 'delay') {
+    let numericValue = typeof value === 'number' ? value : parseFloat(value);
+    if (!Number.isFinite(numericValue) || numericValue < 0) {
+      numericValue = defaultDelay;
+    }
+    numericValue = Math.round((numericValue + Number.EPSILON) * 1000) / 1000;
+    knownBoxes[hostname].delays[day][slotIndex] = numericValue;
+    value = numericValue;
   }
 
   const payload = { hostname, day, triggerIndex: slotIndex };
   if (fieldType === 'letter') {
     payload.letter = value;
-  } else {
+  } else if (fieldType === 'color') {
     payload.color = value;
+  } else if (fieldType === 'delay') {
+    payload.delay = value;
   }
 
   fetch("/update_box", {

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -32,7 +32,8 @@ def _load_webserver(tmp_path):
 def _empty_box(module, ip="1.2.3.4"):
     letters = {day: ["" for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
     colors = {day: [module.DEFAULT_COLOR for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
-    return {"ip": ip, "letters": letters, "colors": colors}
+    delays = {day: [module.DEFAULT_DELAY for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+    return {"ip": ip, "letters": letters, "colors": colors, "delays": delays}
 
 
 @pytest.fixture
@@ -63,11 +64,23 @@ def test_transfer_box_returns_json_on_post_error(webserver_app, monkeypatch):
     module.save_config({"boxen": {"TestBox": box}, "boxOrder": []})
 
     class FakeResponse:
-        def __init__(self, text: str, ok: bool = True) -> None:
+        def __init__(self, text: str = "", ok: bool = True, json_data=None) -> None:
             self.text = text
             self.ok = ok
+            self._json = json_data
 
-    monkeypatch.setattr(module.requests, "get", lambda *_, **__: FakeResponse("", True))
+        def json(self):
+            if self._json is None:
+                raise ValueError("No JSON data")
+            return self._json
+
+    def fake_get(url, *args, **kwargs):
+        if url.endswith("/api/trigger-delays"):
+            delays = {day: [module.DEFAULT_DELAY for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+            return FakeResponse(ok=True, json_data={"delays": delays})
+        return FakeResponse("", True)
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
 
     def raise_post(*args, **kwargs):
         raise module.requests.RequestException("boom")
@@ -103,12 +116,22 @@ def test_update_box_updates_specific_trigger(webserver_app):
     config = module.load_config()
     assert config["boxen"]["TestBox"]["colors"]["mo"][2] == "#123456"
 
+    response = client.post(
+        "/update_box",
+        json={"hostname": "TestBox", "day": "mo", "triggerIndex": 0, "delay": 1.25},
+    )
+
+    assert response.status_code == 200
+    config = module.load_config()
+    assert config["boxen"]["TestBox"]["delays"]["mo"][0] == pytest.approx(1.25)
+
 
 def test_transfer_box_sends_all_triggers_json(webserver_app, monkeypatch):
     module, client = webserver_app
     letters = {day: [f"{day}{idx}" for idx in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
     colors = {day: [f"#0{idx}{idx}{idx}{idx}{idx}"[:7] for idx in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
-    module.save_config({"boxen": {"TestBox": {"ip": "1.2.3.4", "letters": letters, "colors": colors}}, "boxOrder": []})
+    delays = {day: [float(idx) + 0.5 for idx in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+    module.save_config({"boxen": {"TestBox": {"ip": "1.2.3.4", "letters": letters, "colors": colors, "delays": delays}}, "boxOrder": []})
 
     html_parts = ["<html><body>"]
     for index, day in enumerate(module.DAYS):
@@ -123,11 +146,22 @@ def test_transfer_box_sends_all_triggers_json(webserver_app, monkeypatch):
     fake_html = "".join(html_parts)
 
     class FakeResponse:
-        def __init__(self, text: str, ok: bool = True) -> None:
+        def __init__(self, text: str = "", ok: bool = True, json_data=None) -> None:
             self.text = text
             self.ok = ok
+            self._json = json_data
 
-    monkeypatch.setattr(module.requests, "get", lambda *_, **__: FakeResponse(fake_html, True))
+        def json(self):
+            if self._json is None:
+                raise ValueError("No JSON data")
+            return self._json
+
+    def fake_get(url, *args, **kwargs):
+        if url.endswith("/api/trigger-delays"):
+            return FakeResponse(ok=True, json_data={"delays": {day: [0 for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}})
+        return FakeResponse(fake_html, True)
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
 
     captured = {}
 
@@ -146,4 +180,19 @@ def test_transfer_box_sends_all_triggers_json(webserver_app, monkeypatch):
     assert response.status_code == 200
     assert response.get_json() == {"status": "✅ Übertragen"}
     assert captured["url"].endswith("/updateAllLetters")
-    assert captured["json"] == {"letters": letters, "colors": colors}
+    assert captured["json"] == {"letters": letters, "colors": colors, "delays": delays}
+
+
+def test_migrate_config_adds_delay_matrix(webserver_app):
+    module, _ = webserver_app
+    letters = {day: ["" for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+    colors = {day: [module.DEFAULT_COLOR for _ in range(module.TRIGGER_SLOTS)] for day in module.DAYS}
+    legacy_config = {"boxen": {"Legacy": {"ip": "1.2.3.4", "letters": letters, "colors": colors}}, "boxOrder": []}
+
+    module.save_config(legacy_config)
+    migrated = module.load_config()
+
+    assert "delays" in migrated["boxen"]["Legacy"]
+    for day in module.DAYS:
+        assert len(migrated["boxen"]["Legacy"]["delays"][day]) == module.TRIGGER_SLOTS
+        assert all(value == module.DEFAULT_DELAY for value in migrated["boxen"]["Legacy"]["delays"][day])


### PR DESCRIPTION
## Zusammenfassung
- ergänzte die Verwaltungsoberfläche um numerische Eingabefelder für Trigger-Verzögerungen pro Box und Wochentag
- erweiterte den Webserver um Speicherung, Migration und Übertragung der Verzögerungsmatrizen inklusive neuer Lernlogik
- passte die Test-Suite an und ergänzte Fälle zum neuen Verzögerungstransfer

## Tests
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f862c42c1c8330bb445ba76d23c9b0