### PR TITLE
Improve letter display error handling

### DIFF
--- a/src/trigger_handler.h
+++ b/src/trigger_handler.h
@@ -8,8 +8,17 @@ extern bool alreadyCleared;
 
 void clearDisplay();
 
+enum class DisplayLetterError : uint8_t {
+    None = 0,
+    TriggerAlreadyActive,
+    InvalidWeekday,
+    LetterNotFound
+};
+
+extern DisplayLetterError lastDisplayLetterError;
+
 // **Funktion: Buchstaben oder Sonderzeichen anzeigen**
-void displayLetter(uint8_t triggerIndex, char letter);
+bool displayLetter(uint8_t triggerIndex, char letter);
 
 void handleTrigger(char triggerType, bool isAutoMode = false);
 


### PR DESCRIPTION
## Summary
- return detailed status from `displayLetter` and track the last error for diagnostics
- update trigger handling to react to failed display attempts and keep state consistent
- enhance the `/displayLetter` endpoint and front-end script to surface clear HTTP errors to users

## Testing
- `pio run` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f86b548ab08330b9796e475a19d9af