### PR TITLE
Fix config version offset after trigger delay matrix

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -51,7 +51,7 @@ static constexpr size_t EEPROM_TRIGGER_DELAY_MATRIX_SIZE = NUM_TRIGGERS * NUM_DA
 static constexpr uint16_t EEPROM_OFFSET_AUTO_INTERVAL = EEPROM_OFFSET_TRIGGER_DELAY_MATRIX + EEPROM_TRIGGER_DELAY_MATRIX_SIZE;
 static constexpr uint16_t EEPROM_OFFSET_AUTO_MODE = EEPROM_OFFSET_AUTO_INTERVAL + sizeof(unsigned long);
 static constexpr uint16_t EEPROM_OFFSET_WIFI_CONNECT_TIMEOUT = EEPROM_OFFSET_AUTO_MODE + sizeof(uint8_t);
-static constexpr uint16_t EEPROM_OFFSET_CONFIG_VERSION = 400;
+static constexpr uint16_t EEPROM_OFFSET_CONFIG_VERSION = EEPROM_OFFSET_WIFI_CONNECT_TIMEOUT + sizeof(int);
 static constexpr uint16_t EEPROM_CONFIG_VERSION = 3;
 
 // **Standard-WiFi-Daten (werden bei Erststart gesetzt)**


### PR DESCRIPTION
## Summary
- move the configuration version field behind the trigger delay matrix to avoid overlap with delay data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f86d2944e0833087e6b287fb12ed53