### PR TITLE
Implement deferred trigger execution queue

### DIFF
--- a/src/Firmware.ino
+++ b/src/Firmware.ino
@@ -62,8 +62,9 @@ void loop() {
         }
     }
 
-    checkWiFi(); 
+    checkWiFi();
     checkTrigger();
     checkAutoDisplay();
+    processPendingTriggers();
 
 }

--- a/src/trigger_handler.h
+++ b/src/trigger_handler.h
@@ -6,6 +6,14 @@
 
 extern bool alreadyCleared;
 
+struct PendingTrigger {
+    uint8_t triggerIndex;
+    unsigned long executeAt;
+    bool fromWeb;
+};
+
+extern bool pendingTriggerActive;
+
 void clearDisplay();
 
 enum class DisplayLetterError : uint8_t {
@@ -21,6 +29,12 @@ extern DisplayLetterError lastDisplayLetterError;
 bool displayLetter(uint8_t triggerIndex, char letter);
 
 void handleTrigger(char triggerType, bool isAutoMode = false);
+
+bool enqueuePendingTrigger(uint8_t triggerIndex, bool fromWeb);
+
+bool isTriggerPending(uint8_t triggerIndex);
+
+void processPendingTriggers();
 
 void checkTrigger();
 


### PR DESCRIPTION
## Summary
- add a queue for pending triggers to capture manual executions with their planned start time and origin
- process pending triggers from the main loop and update the serial/web trigger handlers to only enqueue manual runs
- remove the blocking delay from `handleTrigger` while keeping auto mode immediate execution intact

## Testing
- not run (pio missing in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f86cf9aaa48330ae7e379aba399ffe