### PR TITLE
Fix config version offset regression (follow-up)

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -96,7 +96,10 @@ void saveConfig() {
     EEPROM.put(EEPROM_OFFSET_WIFI_CONNECT_TIMEOUT, wifi_connect_timeout);
     uint16_t version = EEPROM_CONFIG_VERSION;
     EEPROM.put(EEPROM_OFFSET_CONFIG_VERSION, version);
-    EEPROM.put(EEPROM_OFFSET_CONFIG_VERSION_LEGACY, version);
+    // Do not write to EEPROM_OFFSET_CONFIG_VERSION_LEGACY here because that
+    // address overlaps with the trigger delay matrix in the current layout.
+    // We only read from the legacy offset during migration to avoid
+    // corrupting saved delay values.
     EEPROM.commit();
 
     Serial.println(F("✅ Einstellungen erfolgreich gespeichert!"));


### PR DESCRIPTION
## Summary
- fall back to the legacy EEPROM location when reading the stored config version
- stop writing the config version to the legacy offset to avoid corrupting trigger delays

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f8f96ca9e88330b8d754104a495fcc