### PR TITLE
Preserve scheduled weekday for deferred triggers

### DIFF
--- a/src/trigger_handler.h
+++ b/src/trigger_handler.h
@@ -10,6 +10,7 @@ struct PendingTrigger {
     uint8_t triggerIndex;
     unsigned long executeAt;
     bool fromWeb;
+    int8_t scheduledWeekday;
 };
 
 extern bool pendingTriggerActive;
@@ -26,9 +27,9 @@ enum class DisplayLetterError : uint8_t {
 extern DisplayLetterError lastDisplayLetterError;
 
 // **Funktion: Buchstaben oder Sonderzeichen anzeigen**
-bool displayLetter(uint8_t triggerIndex, char letter);
+bool displayLetter(uint8_t triggerIndex, char letter, int weekdayOverride = -1);
 
-void handleTrigger(char triggerType, bool isAutoMode = false);
+void handleTrigger(char triggerType, bool isAutoMode = false, int weekdayOverride = -1);
 
 bool enqueuePendingTrigger(uint8_t triggerIndex, bool fromWeb);
 


### PR DESCRIPTION
## Summary
- cache the weekday when enqueuing manual triggers and keep it with each pending entry
- extend trigger handling/display to reuse the stored weekday so deferred executions show the intended letter and colors

## Testing
- not run (hardware dependent)


------
https://chatgpt.com/codex/tasks/task_e_68f8f96b54288330b1936a8a97695358