### PR TITLE
Validate RTC input from web endpoint

### DIFF
--- a/src/rtc_manager.h
+++ b/src/rtc_manager.h
@@ -7,7 +7,7 @@ void enableRTC();
 void enableRS485();
 String getRTCTime();
 int getRTCWeekday();
-void setRTCFromWeb(String date, String time);
+bool setRTCFromWeb(const String &date, const String &time);
 void syncTimeWithNTP();
 
 #endif

--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -583,8 +583,11 @@ void setupWebServer() {
         if (request->hasParam("date", true) && request->hasParam("time", true)) {
             String date = request->getParam("date", true)->value();
             String time = request->getParam("time", true)->value();
-            setRTCFromWeb(date, time);
-            request->send(200, "text/plain", "✅ Uhrzeit erfolgreich gesetzt!");
+            if (setRTCFromWeb(date, time)) {
+                request->send(200, "text/plain", "✅ Uhrzeit erfolgreich gesetzt!");
+            } else {
+                request->send(400, "text/plain", "❌ Fehler: Ungültige Datum- oder Zeitangaben!");
+            }
         } else {
             request->send(400, "text/plain", "❌ Fehler: Datum oder Zeit fehlt!");
         }


### PR DESCRIPTION
## Summary
- return a success flag from setRTCFromWeb and validate parsed date/time data before adjusting the RTC
- propagate failures to the /setTime web handler so invalid requests receive an HTTP 400 response

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f8fd9591f88330bfbc62c3f50dd65d