### PR TITLE
Fix EEPROM version offset and improve legacy migration

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -51,8 +51,13 @@ static constexpr size_t EEPROM_TRIGGER_DELAY_MATRIX_SIZE = NUM_TRIGGERS * NUM_DA
 static constexpr uint16_t EEPROM_OFFSET_AUTO_INTERVAL = EEPROM_OFFSET_TRIGGER_DELAY_MATRIX + EEPROM_TRIGGER_DELAY_MATRIX_SIZE;
 static constexpr uint16_t EEPROM_OFFSET_AUTO_MODE = EEPROM_OFFSET_AUTO_INTERVAL + sizeof(unsigned long);
 static constexpr uint16_t EEPROM_OFFSET_WIFI_CONNECT_TIMEOUT = EEPROM_OFFSET_AUTO_MODE + sizeof(uint8_t);
-static constexpr uint16_t EEPROM_OFFSET_CONFIG_VERSION = 400;
+static constexpr uint16_t EEPROM_OFFSET_CONFIG_VERSION = EEPROM_OFFSET_WIFI_CONNECT_TIMEOUT + sizeof(int);
 static constexpr uint16_t EEPROM_CONFIG_VERSION = 3;
+
+static_assert(EEPROM_OFFSET_CONFIG_VERSION >= EEPROM_OFFSET_TRIGGER_DELAY_MATRIX + EEPROM_TRIGGER_DELAY_MATRIX_SIZE,
+              "Config version offset overlaps trigger delay matrix");
+static_assert(EEPROM_OFFSET_CONFIG_VERSION + sizeof(uint16_t) <= EEPROM_SIZE,
+              "Config version exceeds allocated EEPROM size");
 
 // **Standard-WiFi-Daten (werden bei Erststart gesetzt)**
 extern char wifi_ssid[50];

--- a/tests/test_eeprom_layout.py
+++ b/tests/test_eeprom_layout.py
@@ -50,7 +50,10 @@ def test_eeprom_usage_fits_into_memory() -> None:
     eeprom_size = 512
     wifi_connect_end = constants["EEPROM_OFFSET_WIFI_CONNECT_TIMEOUT"] + 4  # sizeof(int)
     version_end = constants["EEPROM_OFFSET_CONFIG_VERSION"] + 2  # uint16_t
+    matrix_end = constants["EEPROM_OFFSET_TRIGGER_DELAY_MATRIX"] + constants["EEPROM_TRIGGER_DELAY_MATRIX_SIZE"]
 
     assert wifi_connect_end <= eeprom_size
     assert version_end <= eeprom_size
+    assert constants["EEPROM_OFFSET_CONFIG_VERSION"] >= wifi_connect_end
+    assert constants["EEPROM_OFFSET_CONFIG_VERSION"] >= matrix_end
     assert constants["EEPROM_CONFIG_VERSION"] >= 3


### PR DESCRIPTION
## Summary
- move the configuration-version field behind the WiFi-timeout slot and guard the layout with static assertions
- detect legacy EEPROM headers at the historical offset and migrate data while reconstructing the trigger-delay matrix
- extend the EEPROM layout regression test to ensure the version block no longer overlaps with other regions

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f9007d70948330abfc00cce8589acc