### PR TITLE
Ensure legacy offset config versions trigger migration

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -212,7 +212,8 @@ void loadConfig() {
     bool migratedLegacyLayout = false;
     uint16_t versionOffset = EEPROM_OFFSET_CONFIG_VERSION;
     uint16_t storedVersion = readStoredConfigVersion(versionOffset);
-    bool usingCurrentLayout = (storedVersion == EEPROM_CONFIG_VERSION);
+    bool usingCurrentLayout = (storedVersion == EEPROM_CONFIG_VERSION &&
+                               versionOffset == EEPROM_OFFSET_CONFIG_VERSION);
 
     if (storedVersion == EEPROM_VERSION_INVALID) {
         Serial.println(F("ℹ️ Keine gültige Konfigurationsversion gefunden – gehe von Legacy-Layout aus."));


### PR DESCRIPTION
## Summary
- only treat the current layout as active when the version is stored at the new offset so legacy headers always migrate

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f94480c5fc83309161cae38385a951