### PR TITLE
Add WiFi inactivity timeout handling

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -70,6 +70,7 @@ extern int wifi_connect_timeout; // Timeout für die WLAN-Verbindung in Sekunden
 extern Ticker display_ticker;
 extern bool triggerActive;
 extern unsigned long letterStartTime;
+extern unsigned long wifiStartTime;
 
 // **Buchstaben für Wochentage (Standardwerte)**
 extern char dailyLetters[NUM_TRIGGERS][NUM_DAYS];

--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -553,6 +553,7 @@ void setupWebServer() {
 
         if (displayed) {
             alreadyCleared = false;
+            wifiStartTime = millis();
             request->send(200, "text/plain", "✅ Buchstabe " + letter + " für Trigger " + String(triggerIndex + 1) + " angezeigt!");
             return;
         }

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -17,6 +17,9 @@ void drawWiFiSymbol();
 // **🌐 WiFi verbinden**
 void connectWiFi();
 
+// **⏹️ WiFi & Webserver deaktivieren**
+void disableWiFiAndServer();
+
 // **🔄 WiFi Reconnect**
 void checkWiFi();
 


### PR DESCRIPTION
## Summary
- track the WiFi start time globally and disable the radio after prolonged inactivity
- add a helper to shut down WiFi and the web server cleanly and refresh the timer on reconnects
- reset the inactivity timer when letters are displayed through the web interface

## Testing
- ⚠️ `pio run` *(command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f9ca36dc4c8330b4e5ad741359be64