### PR TITLE
Expose trigger delay matrix via JSON endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ Die HTTP-Endpunkte `/displayLetter` und `/triggerLetter` akzeptieren optional de
 - Die Weboberfläche stellt die Werte als Tabelle dar und validiert Eingaben auf ganzzahlige Werte zwischen 0 und 999.
 - Die API `/updateTriggerDelays` akzeptiert ein `FormData`-Payload mit Feldern `delay_<triggerIndex>_<dayIndex>` (Indexbeginn 0). Erfolgreiche Aufrufe speichern Matrix, Buchstaben, Farben und sonstige Parameter gemeinsam im EEPROM (`saveConfig()`).
 - Legacy-Konfigurationen mit drei Verzögerungswerten werden beim Laden gleichmäßig auf alle Wochentage verteilt.
+- Die API `/api/trigger-delays` stellt die aktuelle Matrix als JSON mit numerischen Werten bereit. Die Schlüssel folgen den Kürzeln
+  `{"so", "mo", "di", "mi", "do", "fr", "sa"}` und jede Liste enthält die Verzögerungen der drei Trigger (Sekunden):
+
+  ```json
+  {
+    "delays": {
+      "mo": [0, 10, 0],
+      "di": [5, 15, 0]
+    }
+  }
+  ```
+
+  SetupHelper nutzt diesen Endpunkt, um `_normalize_delay_list()` unverändert auf rohe Zahlenwerte anzuwenden.
 
 ## USB-Stick-Setup für das Boxen-Ökosystem
 


### PR DESCRIPTION
## Summary
- add an AsyncWebServer handler for `/api/trigger-delays` that emits the delay matrix as numeric JSON
- document the endpoint in the README for operators integrating with SetupHelper
- extend the SetupHelper webserver tests to validate parsing of numeric trigger delays

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9e26232b88330b1e1ad3b8ec1a595