### PR TITLE
Handle slot-first trigger names with underscore

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -203,6 +203,7 @@ def extract_box_state_from_soup(soup):
                     f"{base_name}_{day_index}_{slot}",
                     f"{base_name}{day_index}_{slot}",
                     f"{base_name}_{slot}_{day_index}",
+                    f"{base_name}{slot}_{day_index}",
                     f"{base_name}_{slot}{day_index}",
                     f"{base_name}{slot}{day_index}",
                 ]


### PR DESCRIPTION
## Summary
- add the missing slot-first field name pattern with an underscore between the slot and day identifiers so legacy HTML is parsed correctly

## Testing
- pytest tests/test_webserver.py *(skipped: Flask not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1ad621008330a0a6eb48add44d37