### PR TITLE
Show WiFi symbol again once the display is idle

### DIFF
--- a/src/trigger_handler.cpp
+++ b/src/trigger_handler.cpp
@@ -1,5 +1,6 @@
 #include "trigger_handler.h"
 #include "rtc_manager.h"
+#include "wifi_manager.h"
 
 DisplayLetterError lastDisplayLetterError = DisplayLetterError::None;
 bool pendingTriggerActive = false;
@@ -36,6 +37,10 @@ void clearDisplay() {
 
     alreadyCleared = true;
     triggerActive = false;
+
+    if (wifiConnected && !wifiDisabled) {
+        drawWiFiSymbol();
+    }
 }
 
 bool isTriggerPending(uint8_t triggerIndex) {


### PR DESCRIPTION
## Summary
- include the WiFi manager header in the trigger handler so the WiFi drawing helper is available
- trigger a redraw of the WiFi symbol after clearing the display when WiFi is connected and not disabled

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fa26546ad48330a23078e7d5beb68f