### PR TITLE
Sichere WiFi-Symbol-Wiederherstellung nach Display-Reset

### DIFF
--- a/src/Firmware.ino
+++ b/src/Firmware.ino
@@ -64,6 +64,10 @@ void loop() {
         if (elapsedTime >= ((unsigned long)letter_display_time * 1000UL)) {
             Serial.println(F("🧹 Anzeigezeit abgelaufen, Buchstabe wird gelöscht!"));
             clearDisplay();
+            if (!triggerActive && wifiConnected && !wifiDisabled) {
+                Serial.println(F("🔁 Sicherheits-Check: WiFi-Symbol nach dem Löschen erneut anzeigen."));
+                drawWiFiSymbol();
+            }
             triggerActive = false;
         }
     }

--- a/src/trigger_handler.cpp
+++ b/src/trigger_handler.cpp
@@ -37,6 +37,7 @@ void clearDisplay() {
 
     alreadyCleared = true;
     triggerActive = false;
+    wifiSymbolVisible = false;
 
     if (wifiConnected && !wifiDisabled) {
         drawWiFiSymbol();
@@ -215,6 +216,7 @@ bool displayLetter(uint8_t triggerIndex, char letter) {
     Serial.print(F(", B="));
     Serial.println(b);
 
+    wifiSymbolVisible = false;
     display.fillScreen(display.color565(0, 0, 0));
     display.display();
     delay(10);

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -3,41 +3,68 @@
 
 // Funktionen aus wifi_manager.h implementiert
 
+bool wifiSymbolVisible = false;
+
 void clearWiFiSymbol() {
-    if (!triggerActive) {
-        Serial.println(F("🚫 WiFi-Symbol wird entfernt."));
-        display.fillScreen(display.color565(0, 0, 0));
-        display.display();
-    } else {
+    if (triggerActive) {
         Serial.println(F("⏳ WiFi-Symbol bleibt, weil ein Buchstabe aktiv ist."));
+        return;
     }
+
+    if (!wifiSymbolVisible) {
+        Serial.println(F("ℹ️ WiFi-Symbol ist bereits ausgeblendet."));
+        return;
+    }
+
+    Serial.println(F("🚫 WiFi-Symbol wird entfernt."));
+    display.fillScreen(display.color565(0, 0, 0));
+    display.display();
+    wifiSymbolVisible = false;
 }
 
 #define SCALE_FACTOR 2
 
 void drawWiFiSymbol() {
-    if (wifiConnected) {
-        Serial.println(F("📶 WiFi-Symbol wird angezeigt."));
+    if (!wifiConnected) {
+        Serial.println(F("ℹ️ WiFi-Symbol wird nicht angezeigt: keine aktive WLAN-Verbindung."));
+        wifiSymbolVisible = false;
+        return;
+    }
 
-        if (!triggerActive) {
-            display.fillScreen(display.color565(0, 0, 255));
+    if (wifiDisabled) {
+        Serial.println(F("ℹ️ WiFi-Symbol bleibt deaktiviert, weil WiFi abgeschaltet ist."));
+        wifiSymbolVisible = false;
+        return;
+    }
 
-            int x_pos = (64 - (32 * SCALE_FACTOR)) / 2;
-            int y_pos = (64 - (32 * SCALE_FACTOR)) / 2;
+    if (triggerActive) {
+        Serial.println(F("⏳ WiFi-Symbol NICHT angezeigt, weil ein Buchstabe aktiv ist."));
+        wifiSymbolVisible = false;
+        return;
+    }
 
-            for (int y = 0; y < 32; y++) {
-                for (int x = 0; x < 32; x++) {
-                    uint8_t rowValue = pgm_read_byte(&letterData['~'][y * 4 + (x / 8)]);
-                    if (rowValue & (1 << (7 - (x % 8)))) {
-                        display.fillRect(x_pos + x * SCALE_FACTOR, y_pos + y * SCALE_FACTOR, SCALE_FACTOR, SCALE_FACTOR, display.color565(0, 0, 0));
-                    }
-                }
+    if (wifiSymbolVisible) {
+        Serial.println(F("ℹ️ WiFi-Symbol ist bereits aktiv – erneutes Zeichnen entfällt."));
+        return;
+    }
+
+    Serial.println(F("📶 WiFi-Symbol wird angezeigt."));
+
+    display.fillScreen(display.color565(0, 0, 255));
+
+    int x_pos = (64 - (32 * SCALE_FACTOR)) / 2;
+    int y_pos = (64 - (32 * SCALE_FACTOR)) / 2;
+
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 32; x++) {
+            uint8_t rowValue = pgm_read_byte(&letterData['~'][y * 4 + (x / 8)]);
+            if (rowValue & (1 << (7 - (x % 8)))) {
+                display.fillRect(x_pos + x * SCALE_FACTOR, y_pos + y * SCALE_FACTOR, SCALE_FACTOR, SCALE_FACTOR, display.color565(0, 0, 0));
             }
-            display.display();
-        } else {
-            Serial.println(F("⏳ WiFi-Symbol NICHT angezeigt, weil ein Buchstabe aktiv ist."));
         }
     }
+    display.display();
+    wifiSymbolVisible = true;
 }
 
 void disableWiFiAndServer() {

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -7,6 +7,7 @@
 
 extern bool wifiDisabled;
 extern bool triggerActive;
+extern bool wifiSymbolVisible;
 
 // **❌ WiFi-Symbol entfernen, wenn die Verbindung abbricht**
 void clearWiFiSymbol();


### PR DESCRIPTION
## Zusammenfassung
- ergänzt `clearDisplay()` um das Zurücksetzen des WiFi-Symbol-Status und bindet die erneute Anzeige an die WLAN-Flags
- führt einen Sicherheitsaufruf in `loop()` ein, damit das WiFi-Symbol auch bei späteren Änderungen nach dem Löschen erhalten bleibt
- erweitert das WiFi-Management um einen Sichtbarkeitsstatus und zusätzliche Guards, um Mehrfachaufrufe sauber zu protokollieren

## Tests
- nicht ausgeführt (Firmware-Umgebung nicht automatisiert testbar)


------
https://chatgpt.com/codex/tasks/task_e_68fa29e302e483308229e9e523463b79