### PR TITLE
Leert das WLAN-Passwort wenn kein neues gesetzt wird

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -613,7 +613,10 @@ void setupWebServer() {
             if (applyPassword) {
                 passwordTruncated = copyWithTermination(sanitizedPassword, wifi_password, sizeof(wifi_password));
             } else {
-                wifi_password[sizeof(wifi_password) - 1] = '\0';
+                for (size_t idx = 0; idx < sizeof(wifi_password); ++idx) {
+                    wifi_password[idx] = '\0';
+                }
+                Serial.println(F("[WebManager] WLAN-Passwort zurückgesetzt."));
             }
 
             saveConfig();


### PR DESCRIPTION
## Summary
- leere den gesamten WLAN-Passwortpuffer, wenn kein Passwort übermittelt wird
- ergänze ein Debug-Log zur Dokumentation des zurückgesetzten Passworts
- bewahre den bestehenden Speichervorgang zur Persistierung der Änderung

## Testing
- pytest tests/test_webserver.py (skipped: Flask nicht installiert)


------
https://chatgpt.com/codex/tasks/task_e_68fa341cd2e08330a0f472fca93e04c3