### PR TITLE
Fix: Preserve WiFi password unless explicitly cleared

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -599,6 +599,7 @@ void setupWebServer() {
             const String sanitizedHostname = normalizeInput(hostnameParam);
             const String sanitizedPassword = hasPasswordParam ? normalizeInput(passwordParam) : String();
             const bool applyPassword = hasPasswordParam && !sanitizedPassword.isEmpty();
+            const bool clearPassword = hasPasswordParam && sanitizedPassword.isEmpty();
 
             auto copyWithTermination = [](const String &input, char *destination, size_t destinationSize) {
                 strncpy(destination, input.c_str(), destinationSize);
@@ -612,7 +613,7 @@ void setupWebServer() {
 
             if (applyPassword) {
                 passwordTruncated = copyWithTermination(sanitizedPassword, wifi_password, sizeof(wifi_password));
-            } else {
+            } else if (clearPassword) {
                 for (size_t idx = 0; idx < sizeof(wifi_password); ++idx) {
                     wifi_password[idx] = '\0';
                 }


### PR DESCRIPTION
## Summary
- behalte das gespeicherte WLAN-Passwort, wenn kein Passwort-Parameter übermittelt wird
- setze den Passwortpuffer weiterhin zurück, wenn explizit ein leeres Passwort gesendet wird
- bewahre das bestehende Debug-Log zum Dokumentieren des Zurücksetzens

## Testing
- pytest tests/test_webserver.py (skipped: Flask nicht installiert)


------
https://chatgpt.com/codex/tasks/task_e_68fa3ab599808330a19d4ad9eb5877a8