### PR TITLE
Follow-up: Allow empty WiFi password submissions to clear credentials

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -557,9 +557,9 @@ void setupWebServer() {
         if (request->hasParam("ssid", true) && request->hasParam("hostname", true)) {
             const String ssidParam = request->getParam("ssid", true)->value();
             const String hostnameParam = request->getParam("hostname", true)->value();
-            const bool hasPasswordParam = request->hasParam("password", true) &&
-                                          request->getParam("password", true)->value() != "";
-            const String passwordParam = hasPasswordParam ? request->getParam("password", true)->value() : String();
+            const bool passwordParamProvided = request->hasParam("password", true);
+            const String passwordParam =
+                passwordParamProvided ? request->getParam("password", true)->value() : String();
 
             auto containsForbiddenChars = [](const String &value) {
                 for (size_t idx = 0; idx < value.length(); ++idx) {
@@ -586,7 +586,7 @@ void setupWebServer() {
             if (containsForbiddenChars(hostnameParam)) {
                 validationError += "Hostname enthält ungültige Zeichen. ";
             }
-            if (hasPasswordParam && containsForbiddenChars(passwordParam)) {
+            if (passwordParamProvided && containsForbiddenChars(passwordParam)) {
                 validationError += "Passwort enthält ungültige Zeichen. ";
             }
 
@@ -597,9 +597,10 @@ void setupWebServer() {
 
             const String sanitizedSsid = normalizeInput(ssidParam);
             const String sanitizedHostname = normalizeInput(hostnameParam);
-            const String sanitizedPassword = hasPasswordParam ? normalizeInput(passwordParam) : String();
-            const bool applyPassword = hasPasswordParam && !sanitizedPassword.isEmpty();
-            const bool clearPassword = hasPasswordParam && sanitizedPassword.isEmpty();
+            const String sanitizedPassword =
+                passwordParamProvided ? normalizeInput(passwordParam) : String();
+            const bool applyPassword = passwordParamProvided && !sanitizedPassword.isEmpty();
+            const bool clearPassword = passwordParamProvided && sanitizedPassword.isEmpty();
 
             auto copyWithTermination = [](const String &input, char *destination, size_t destinationSize) {
                 strncpy(destination, input.c_str(), destinationSize);


### PR DESCRIPTION
## Summary
- treat WiFi password submissions as provided when the parameter exists, even if empty
- keep applying a new password only for non-empty values while empty submissions clear the stored credential

## Testing
- pytest tests/test_webserver.py (skipped: Flask not installed)


------
https://chatgpt.com/codex/tasks/task_e_68fa4e29d5808330b2fe89386d3574b9