### PR TITLE
WiFi-Idle-Timer beim Webserver dokumentiert

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -439,9 +439,10 @@ const char scriptJS[] PROGMEM = R"rawliteral(
 )rawliteral";
 
 void setupWebServer() {
-    // ℹ️ Hinweis: Für jede neue Route mit Benutzerinteraktion unbedingt
-    //             refreshWiFiIdleTimer(...) aufrufen, damit der WLAN-Timeout
-    //             bei aktiver Nutzung zurückgesetzt wird (siehe wifi_manager.cpp).
+    // ℹ️ Hinweis: Der Helper refreshWiFiIdleTimer(...) aus wifi_manager.cpp muss
+    //             zu Beginn jeder neuen Route mit echter Nutzerinteraktion
+    //             aufgerufen werden, damit der WLAN-Timeout zuverlässig
+    //             zurückgesetzt wird.
     server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
         refreshWiFiIdleTimer(F("GET /"));
         String html = "<h1>Märchen Einstellungen</h1>";

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -11,8 +11,6 @@ void refreshWiFiIdleTimer(const __FlashStringHelper *reason) {
     if (reason != nullptr) {
         Serial.print(F("🔄 WiFi-Idle-Timer aktualisiert: "));
         Serial.println(reason);
-    } else {
-        Serial.println(F("🔄 WiFi-Idle-Timer aktualisiert."));
     }
 }
 


### PR DESCRIPTION
## Summary
- passe den WiFi-Idle-Timer-Helper an, sodass das Debug-Logging optional über einen Grund-Parameter ausgelöst wird
- dokumentiere direkt in setupWebServer(), dass alle Interaktionen den Helper nutzen müssen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa53c0ebac833098d9d816ee5a7bbc