### PR TITLE
Remove brittle hostname gate before parsing

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -281,13 +281,6 @@ def get_connected_devices():
                 if len(parts) >= 3:
                     ip = parts[2]
                     if subprocess.call(["ping", "-c", "1", "-W", "1", ip], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
-                        try:
-                            r = requests.get(f"http://{ip}/", timeout=3)
-                            if not r.ok or "name='hostname'" not in r.text:
-                                continue
-                        except:
-                            continue
-
                         hostname = get_hostname_from_web(ip)
                         if hostname == "Unbekannt":
                             continue


### PR DESCRIPTION
## Summary
- remove the preflight string check that skipped pages without the exact hostname attribute formatting
- rely on the BeautifulSoup-based helper to determine whether a hostname was found

## Testing
- pytest tests/test_webserver.py


------
https://chatgpt.com/codex/tasks/task_e_68fa6d1a058c83309549b04f2362af9a