### PR TITLE
Fix auto interval clamp to avoid Arduino min/max macros

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -322,7 +322,11 @@ void loadConfig() {
     if (restoredDefaultAutoInterval) {
         letter_auto_display_interval = 300UL;
     } else {
-        letter_auto_display_interval = std::min(std::max(letter_auto_display_interval, 30UL), 600UL);
+        if (letter_auto_display_interval < 30UL) {
+            letter_auto_display_interval = 30UL;
+        } else if (letter_auto_display_interval > 600UL) {
+            letter_auto_display_interval = 600UL;
+        }
     }
 
     if (originalAutoInterval != letter_auto_display_interval) {


### PR DESCRIPTION
## Summary
- replace the std::min/std::max clamp with explicit comparisons so Arduino's min/max macros no longer break compilation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa743631ac8330b313dc09d43eb1d9