### PR TITLE
Ensure WiFi STA mode without residual SoftAP

### DIFF
--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -93,6 +93,8 @@ void disableWiFiAndServer() {
     server.end();
     WiFi.disconnect();
     WiFi.mode(WIFI_OFF);
+    WiFi.softAPdisconnect(true);
+    Serial.println(F("ℹ️ SoftAP nach Abschaltung getrennt."));
 
     wifiConnected = false;
     wifiDisabled = true;
@@ -100,6 +102,10 @@ void disableWiFiAndServer() {
 
 void connectWiFi() {
     Serial.println(F("🌐 Verbinde mit WiFi..."));
+    WiFi.persistent(false);
+    WiFi.mode(WIFI_STA);
+    WiFi.softAPdisconnect(true);
+    Serial.println(F("ℹ️ STA-Modus aktiviert, SoftAP getrennt."));
     WiFi.hostname(hostname);
     WiFi.begin(wifi_ssid, wifi_password);
 


### PR DESCRIPTION
## Summary
- disable the ESP8266 SoftAP explicitly when connecting in STA mode
- turn off any lingering SoftAP when shutting WiFi down and log the action

## Testing
- platformio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fa7e689d64833087010a879aef8fd4