### PR TITLE
Fix STA reconnect by preserving STA radio state

### DIFF
--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -103,8 +103,8 @@ void disableWiFiAndServer() {
 void connectWiFi() {
     Serial.println(F("🌐 Verbinde mit WiFi..."));
     WiFi.persistent(false);
+    WiFi.softAPdisconnect();
     WiFi.mode(WIFI_STA);
-    WiFi.softAPdisconnect(true);
     Serial.println(F("ℹ️ STA-Modus aktiviert, SoftAP getrennt."));
     WiFi.hostname(hostname);
     WiFi.begin(wifi_ssid, wifi_password);


### PR DESCRIPTION
## Summary
- stop using `WiFi.softAPdisconnect(true)` before reconnecting in station mode so the radio stays enabled
- disconnect the lingering SoftAP before switching back to station mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa84e51fdc83309da89a12185ced67