### PR TITLE
Ensure AsyncWebServer status survives WiFi reconnects

### DIFF
--- a/src/Firmware.ino
+++ b/src/Firmware.ino
@@ -24,6 +24,8 @@ void setup() {
   Serial.println(F("🚀 Systemstart..."));
   // clearDisplay();
 
+  webServerRunning = false;
+
   pinMode(GPIO_RS485_ENABLE, OUTPUT);
   digitalWrite(GPIO_RS485_ENABLE, LOW);
 

--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -1279,4 +1279,6 @@ void setupWebServer() {
     });
 
     server.begin();
+    webServerRunning = true;
+    Serial.println(F("✅ Webserver gestartet und Listener aktiv."));
 }

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -4,6 +4,7 @@
 // Funktionen aus wifi_manager.h implementiert
 
 bool wifiSymbolVisible = false;
+bool webServerRunning = false;
 
 void refreshWiFiIdleTimer(const __FlashStringHelper *reason) {
     wifiStartTime = millis();
@@ -90,7 +91,12 @@ void disableWiFiAndServer() {
         Serial.println(F("⏳ Aktive Anzeige – WiFi-Symbol bleibt vorerst bestehen."));
     }
 
-    server.end();
+    if (webServerRunning) {
+        server.end();
+        webServerRunning = false;
+    } else {
+        Serial.println(F("ℹ️ Webserver war bereits gestoppt."));
+    }
     WiFi.disconnect();
     WiFi.mode(WIFI_OFF);
     WiFi.softAPdisconnect(true);
@@ -156,6 +162,12 @@ void checkWiFi() {
             wifiConnected = true;
             wifiDisabled = false;
             refreshWiFiIdleTimer(F("checkWiFi reconnect"));
+
+            if (!webServerRunning) {
+                Serial.println(F("🌐 Webserver war gestoppt – starte Listener neu."));
+                server.begin();
+                webServerRunning = true;
+            }
 
             if (!triggerActive) {
                 drawWiFiSymbol();

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -10,6 +10,10 @@ extern bool wifiDisabled;
 extern bool triggerActive;
 extern bool wifiSymbolVisible;
 
+// **📊 Laufzeitstatus des AsyncWebServer**
+// Hilft dabei, den Listener bei WLAN-Reconnects gezielt neu zu starten.
+extern bool webServerRunning;
+
 // **❌ WiFi-Symbol entfernen, wenn die Verbindung abbricht**
 void clearWiFiSymbol();
 


### PR DESCRIPTION
## Summary
- introduce a shared `webServerRunning` flag to document and track the AsyncWebServer lifecycle
- reset the flag during firmware startup and when disabling WiFi so the listener status stays consistent
- restart the web server if WiFi reconnects while the listener is stopped and confirm successful startup logging

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fa84d41f308330a31b51695dbe3e3c