### PR TITLE
Implement RTC weekday caching for trigger handling

### DIFF
--- a/src/Firmware.ino
+++ b/src/Firmware.ino
@@ -52,8 +52,9 @@ void setup() {
 
 void loop() {
     static unsigned long lastDebugTime = 0;
+    static unsigned long lastWeekdayUpdate = 0;
 
-    if (triggerActive) {  
+    if (triggerActive) {
         unsigned long elapsedTime = millis() - letterStartTime;
 
         // **Nur alle 1000 ms (1 Sekunde) eine Debug-Ausgabe**
@@ -72,6 +73,12 @@ void loop() {
             }
             triggerActive = false;
         }
+    }
+
+    const unsigned long nowForWeekday = millis();
+    if ((nowForWeekday - lastWeekdayUpdate) >= 500UL) {
+        updateCachedWeekday();
+        lastWeekdayUpdate = nowForWeekday;
     }
 
     checkWiFi();

--- a/src/rtc_manager.h
+++ b/src/rtc_manager.h
@@ -5,6 +5,10 @@
 
 void enableRTC();
 void enableRS485();
+bool updateCachedWeekday(bool waitForIdle = false);
+bool isWeekdayCacheValid();
+int getCachedWeekday();
+void invalidateWeekdayCache();
 String getRTCTime();
 int getRTCWeekday();
 bool setRTCFromWeb(const String &date, const String &time);


### PR DESCRIPTION
## Summary
- add a cached RTC weekday with update helper so the RS485 transceiver can stay enabled while triggers run
- refresh the weekday cache periodically from the main loop and have trigger queuing/execution rely solely on the cached value
- update RTC setters to keep the cache in sync after manual or NTP adjustments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa8a4eb2f4833084e97c6c286700c8