### PR TITLE
Invalidate stale RTC weekday cache during serial activity

### DIFF
--- a/src/rtc_manager.cpp
+++ b/src/rtc_manager.cpp
@@ -60,7 +60,9 @@ bool updateCachedWeekday(bool waitForIdle) {
   }
 
   const unsigned long now = millis();
-  if (cachedWeekdayValid && (now - cachedWeekdayTimestamp) < WEEKDAY_CACHE_MAX_AGE_MS) {
+  const bool cacheFresh =
+      cachedWeekdayValid && (now - cachedWeekdayTimestamp) < WEEKDAY_CACHE_MAX_AGE_MS;
+  if (cacheFresh) {
     return true;
   }
 
@@ -75,6 +77,9 @@ bool updateCachedWeekday(bool waitForIdle) {
     }
 
     if (Serial.available() > 0) {
+      if (!cacheFresh) {
+        cachedWeekdayValid = false;
+      }
       return cachedWeekdayValid;
     }
   }


### PR DESCRIPTION
## Summary
- ensure skipped RTC weekday refreshes do not leave stale cache entries marked valid by tracking freshness when serial traffic blocks RTC access

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa94c53098833086aaa8aaaef2307f