### PR TITLE
Korrigiere Firmware-Tagesindizes im Webserver

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -228,9 +228,13 @@ def extract_box_state_from_soup(soup):
                     ]
                 )
 
-        extend_candidates(firmware_day_index)
-        if fallback_day_index is not None and fallback_day_index != firmware_day_index:
+        if fallback_day_index is not None:
             extend_candidates(fallback_day_index)
+        if (
+            firmware_day_index is not None
+            and firmware_day_index != fallback_day_index
+        ):
+            extend_candidates(firmware_day_index)
 
         for candidate in dict.fromkeys(name_candidates):
             field = soup.find(tag, {"name": candidate})


### PR DESCRIPTION
## Zusammenfassung
- ergänze eine explizite Abbildung der Firmware-Tagesindizes und verwende sie beim Ermitteln der Formularfelder
- erweitere die Verarbeitung der Trigger-Verzögerungen um die neue Zuordnung samt Fallback für numerische Schlüssel
- füge einen Integrationstest hinzu, der das HTML aus `web_manager.cpp` für alle sieben Wochentage simuliert und die Zuordnung der Werte prüft
- passe die Auswahlreihenfolge der Formular-Indizes an, damit Legacy-Sonntage nicht mehr auf Montagsfelder abgebildet werden

## Tests
- pytest tests/test_webserver.py *(Flask nicht installiert, Suite wird übersprungen)*

------
https://chatgpt.com/codex/tasks/task_e_68fa94bfad508330a7c6bbea983a758b