### PR TITLE
Berücksichtige Trigger-Quelle beim WLAN-Handling

### DIFF
--- a/src/trigger_handler.h
+++ b/src/trigger_handler.h
@@ -28,7 +28,7 @@ extern DisplayLetterError lastDisplayLetterError;
 // **Funktion: Buchstaben oder Sonderzeichen anzeigen**
 bool displayLetter(uint8_t triggerIndex, char letter);
 
-void handleTrigger(char triggerType, bool isAutoMode = false);
+void handleTrigger(char triggerType, bool isAutoMode = false, bool fromWeb = false);
 
 bool enqueuePendingTrigger(uint8_t triggerIndex, bool fromWeb);
 


### PR DESCRIPTION
## Summary
- erweitere die Signatur von `handleTrigger`, um Web-Trigger gesondert zu kennzeichnen
- reiche die Trigger-Quelle in der Abarbeitung der Warteschlange weiter und setze Standardwerte im Automodus
- verhindere die WLAN-Abschaltung für Trigger aus dem Web oder Automodus und erweitere das Logging entsprechend

## Testing
- nicht ausgeführt (Hardware/Weboberfläche im Container nicht verfügbar)


------
https://chatgpt.com/codex/tasks/task_e_68fa94a477ec8330af09e32ca94e9517