### PR TITLE
Absicherung der Trigger-Verzögerungsaktualisierung

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -714,6 +714,14 @@ void setupWebServer() {
 
     server.on("/updateTriggerDelays", HTTP_POST, [](AsyncWebServerRequest *request) {
         refreshWiFiIdleTimer(F("POST /updateTriggerDelays"));
+
+        unsigned long parsedDelays[NUM_TRIGGERS][NUM_DAYS];
+        for (size_t trigger = 0; trigger < NUM_TRIGGERS; ++trigger) {
+            for (size_t day = 0; day < NUM_DAYS; ++day) {
+                parsedDelays[trigger][day] = letter_trigger_delays[trigger][day];
+            }
+        }
+
         bool success = true;
 
         for (size_t trigger = 0; trigger < NUM_TRIGGERS && success; ++trigger) {
@@ -750,11 +758,17 @@ void setupWebServer() {
                     break;
                 }
 
-                letter_trigger_delays[trigger][day] = parsed;
+                parsedDelays[trigger][day] = parsed;
             }
         }
 
         if (success) {
+            for (size_t trigger = 0; trigger < NUM_TRIGGERS; ++trigger) {
+                for (size_t day = 0; day < NUM_DAYS; ++day) {
+                    letter_trigger_delays[trigger][day] = parsedDelays[trigger][day];
+                }
+            }
+
             saveConfig();
             request->send(200, "text/plain", "✅ Verzögerungsmatrix gespeichert!");
         } else {


### PR DESCRIPTION
## Summary
- puffere eingehende Verzögerungswerte in einem temporären Array
- validiere alle Formularwerte vollständig bevor die globale Matrix überschrieben wird
- übernehme geprüfte Werte gesammelt und sichere sie per saveConfig()

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68faff5475c08330802017b0233f1594