### PR TITLE
Plattformneutrale Erkennung gelöschter EEPROM-Werte

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Nach der Einrichtung zeigt die Firmware die Buchstaben automatisch an und kann �
 
 `config.h` enthält Platzhalter-WLAN-Daten, falls noch nichts im EEPROM gespeichert ist. Echte Zugangsdaten sollten **nicht** ins Repository gelangen. Sie können initial über das EEPROM oder die Konfigurationsseite gesetzt werden. Der Parameter `wifi_connect_timeout` bestimmt, wie lange die Verbindung versucht wird (Standard 30 Sekunden).
 
+> **Hinweis:** Die Firmware erkennt jetzt gelöschte EEPROM-Zellen plattformunabhängig. Vergleiche gegen `0xFF` erfolgen explizit auf `uint8_t`-Basis, sodass Host-Tests und der ESP8266 dieselbe Initialisierung der WLAN-Defaults auslösen.
+
 ### Mehrspuriges Buchstabenraster
 
 Die Tagesbuchstaben werden jetzt dreidimensional abgelegt:

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -165,7 +165,7 @@ void migrateLegacyLayout(uint16_t storedVersion, bool &migratedLegacyLayout) {
 
     for (size_t day = 0; day < NUM_DAYS; ++day) {
         char letter = legacyLetters[day];
-        if (letter == '\xFF' || letter == '\0') {
+        if (static_cast<uint8_t>(letter) == 0xFF || letter == '\0') {
             letter = DEFAULT_DAILY_LETTERS[0][day];
         }
 
@@ -302,7 +302,7 @@ void loadConfig() {
 
     bool eepromUpdated = migratedLegacyLayout;
 
-    bool wifiErased = (wifi_ssid[0] == '\xFF');
+    bool wifiErased = (static_cast<uint8_t>(wifi_ssid[0]) == 0xFF);
     bool wifiEmpty = (wifi_ssid[0] == '\0');
     bool wifiLengthZero = false;
     if (!wifiErased && !wifiEmpty) {


### PR DESCRIPTION
## Zusammenfassung
- Erzwingt `uint8_t`-Vergleiche gegen 0xFF beim Laden von Legacy-Buchstaben und WLAN-Defaults, damit gelöschte EEPROM-Zellen unabhängig vom Toolchain-Verhalten erkannt werden.
- Dokumentiert im README die plattformunabhängige Erkennung gelöschter EEPROM-Zellen und die damit verbundene Default-Initialisierung.

## Tests
- `pio run` *(fehlschlagend: bestehender Build-Fehler wegen `AsyncWebParameter`-Konvertierungen in `web_manager.cpp`)*
- `pytest tests/test_config_sanitization.py -q`
- `g++ -std=c++17 -DRIDDLEMATRIX_HOST_TEST -Itests/stubs -Isrc -o /tmp/test_wifi_reset /tmp/test_wifi_reset.cpp src/config.cpp && /tmp/test_wifi_reset`


------
https://chatgpt.com/codex/tasks/task_e_68fb23fcb84c833094e51f59f394a231