### PR TITLE
Ensure display updater ISR resides in IRAM

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -496,7 +496,7 @@ void loadConfig() {
     }
 }
 
-void display_updater() {
+void IRAM_ATTR display_updater() {
     display.display();
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -120,6 +120,15 @@ extern bool wifiConnected;
 extern const char* daysOfTheWeek[7];
 
 
+// **Attribut für Interrupt-Routinen im IRAM sicherstellen**
+#if !defined(IRAM_ATTR)
+#  if defined(ICACHE_RAM_ATTR)
+#    define IRAM_ATTR ICACHE_RAM_ATTR
+#  else
+#    define IRAM_ATTR
+#  endif
+#endif
+
 // **💾 Einstellungen speichern in EEPROM**
 void saveConfig();
 
@@ -127,7 +136,7 @@ void saveConfig();
 void loadConfig();
 
 
-void display_updater();
+void IRAM_ATTR display_updater();
 
 // **LED-Matrix Setup-Funktion**
 void setupMatrix();


### PR DESCRIPTION
## Summary
- add compatibility macro so IRAM attributes are available even on older toolchains
- annotate the display updater ISR to ensure it is placed in IRAM

## Testing
- ⚠️ `pio run` *(fehlgeschlagen: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fb333296a48330932b4d677230c6c1