### PR TITLE
Detect EEPROM v3 config version and add migration test

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -47,6 +47,7 @@ const char* daysOfTheWeek[7] = {"Sonntag", "Montag", "Dienstag", "Mittwoch", "Do
 namespace {
 
 constexpr uint16_t EEPROM_OFFSET_CONFIG_VERSION_LEGACY = 400;
+constexpr uint16_t EEPROM_OFFSET_CONFIG_VERSION_V3 = 469; // 0x1D5
 constexpr uint16_t EEPROM_VERSION_INVALID = 0xFFFF;
 
 constexpr uint16_t EEPROM_OFFSET_DAILY_LETTER_COLORS_V3 = 200;
@@ -139,6 +140,13 @@ uint16_t readStoredConfigVersion(uint16_t &versionOffset) {
 
     if (isLikelyValidVersion(storedVersion)) {
         return storedVersion;
+    }
+
+    uint16_t version3Value = EEPROM_VERSION_INVALID;
+    EEPROM.get(EEPROM_OFFSET_CONFIG_VERSION_V3, version3Value);
+    if (isLikelyValidVersion(version3Value)) {
+        versionOffset = EEPROM_OFFSET_CONFIG_VERSION_V3;
+        return version3Value;
     }
 
     uint16_t legacyVersion = EEPROM_VERSION_INVALID;

--- a/tests/config_v3_migration_harness.cpp
+++ b/tests/config_v3_migration_harness.cpp
@@ -1,0 +1,112 @@
+#include "config.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+SerialClass Serial;
+ESPClass ESP;
+FakeEEPROMClass EEPROM;
+Ticker display_ticker;
+bool triggerActive = false;
+unsigned long letterStartTime = 0;
+unsigned long wifiStartTime = 0;
+AsyncWebServer server(80);
+
+namespace {
+constexpr uint16_t OFFSET_CONFIG_VERSION_V3 = 469;
+constexpr uint16_t OFFSET_DAILY_LETTER_COLORS_V3 = 200;
+constexpr uint16_t OFFSET_DISPLAY_BRIGHTNESS_V3 =
+    OFFSET_DAILY_LETTER_COLORS_V3 + (NUM_TRIGGERS * NUM_DAYS * COLOR_STRING_LENGTH);
+constexpr uint16_t OFFSET_LETTER_DISPLAY_TIME_V3 = OFFSET_DISPLAY_BRIGHTNESS_V3 + sizeof(int32_t);
+constexpr uint16_t OFFSET_TRIGGER_DELAY_MATRIX_V3 = OFFSET_LETTER_DISPLAY_TIME_V3 + sizeof(uint32_t);
+constexpr uint16_t OFFSET_AUTO_INTERVAL_V3 =
+    OFFSET_TRIGGER_DELAY_MATRIX_V3 + (NUM_TRIGGERS * NUM_DAYS * sizeof(uint32_t));
+constexpr uint16_t OFFSET_AUTO_MODE_V3 = OFFSET_AUTO_INTERVAL_V3 + sizeof(uint32_t);
+constexpr uint16_t OFFSET_WIFI_CONNECT_TIMEOUT_V3 = OFFSET_AUTO_MODE_V3 + sizeof(uint8_t);
+
+constexpr char TEST_LETTERS[NUM_TRIGGERS][NUM_DAYS] = {
+    {'A', 'B', 'C', 'D', 'E', 'F', 'G'},
+    {'H', 'I', 'J', 'K', 'L', 'M', 'N'},
+    {'O', 'P', 'Q', 'R', 'S', 'T', 'U'},
+};
+
+constexpr char TEST_COLORS[NUM_TRIGGERS][NUM_DAYS][COLOR_STRING_LENGTH] = {
+    {"#000001", "#000002", "#000003", "#000004", "#000005", "#000006", "#000007"},
+    {"#000101", "#000102", "#000103", "#000104", "#000105", "#000106", "#000107"},
+    {"#000201", "#000202", "#000203", "#000204", "#000205", "#000206", "#000207"},
+};
+
+constexpr uint32_t TEST_TRIGGER_DELAYS[NUM_TRIGGERS][NUM_DAYS] = {
+    {1, 1, 1, 1, 1, 1, 1},
+    {2, 2, 2, 2, 2, 2, 2},
+    {3, 3, 3, 3, 3, 3, 3},
+};
+
+void write_u16(uint16_t offset, uint16_t value) {
+    std::memcpy(EEPROM.raw() + offset, &value, sizeof(value));
+}
+
+void write_u32(uint16_t offset, uint32_t value) {
+    std::memcpy(EEPROM.raw() + offset, &value, sizeof(value));
+}
+
+void write_i32(uint16_t offset, int32_t value) {
+    std::memcpy(EEPROM.raw() + offset, &value, sizeof(value));
+}
+}
+
+int main() {
+    EEPROM.begin(EEPROM_SIZE);
+    EEPROM.fill(0xFF);
+
+    uint8_t *raw = EEPROM.raw();
+
+    std::memcpy(raw + EEPROM_OFFSET_DAILY_LETTERS, TEST_LETTERS, sizeof(TEST_LETTERS));
+    std::memcpy(raw + OFFSET_DAILY_LETTER_COLORS_V3, TEST_COLORS, sizeof(TEST_COLORS));
+
+    write_i32(OFFSET_DISPLAY_BRIGHTNESS_V3, 123);
+    write_u32(OFFSET_LETTER_DISPLAY_TIME_V3, 17);
+
+    for (size_t trigger = 0; trigger < NUM_TRIGGERS; ++trigger) {
+        for (size_t day = 0; day < NUM_DAYS; ++day) {
+            size_t index = (trigger * NUM_DAYS) + day;
+            write_u32(static_cast<uint16_t>(OFFSET_TRIGGER_DELAY_MATRIX_V3 + index * sizeof(uint32_t)),
+                      TEST_TRIGGER_DELAYS[trigger][day]);
+        }
+    }
+
+    write_u32(OFFSET_AUTO_INTERVAL_V3, 555);
+    raw[OFFSET_AUTO_MODE_V3] = 1;
+    write_i32(OFFSET_WIFI_CONNECT_TIMEOUT_V3, 42);
+    write_u16(OFFSET_CONFIG_VERSION_V3, 3);
+
+    loadConfig();
+
+    bool success = true;
+
+    for (size_t trigger = 0; trigger < NUM_TRIGGERS; ++trigger) {
+        for (size_t day = 0; day < NUM_DAYS; ++day) {
+            if (std::strncmp(dailyLetterColors[trigger][day], TEST_COLORS[trigger][day], COLOR_STRING_LENGTH) != 0) {
+                std::cerr << "Mismatch in colors at trigger " << trigger << ", day " << day << " -> actual "
+                          << dailyLetterColors[trigger][day] << " expected " << TEST_COLORS[trigger][day]
+                          << std::endl;
+                success = false;
+            }
+        }
+    }
+
+    if (!autoDisplayMode) {
+        std::cerr << "Auto mode not migrated correctly" << std::endl;
+        success = false;
+    }
+
+    uint16_t versionAfter = 0;
+    EEPROM.get(EEPROM_OFFSET_CONFIG_VERSION, versionAfter);
+    if (versionAfter != EEPROM_CONFIG_VERSION) {
+        std::cerr << "Unexpected config version after migration: " << versionAfter << std::endl;
+        success = false;
+    }
+
+    return success ? 0 : 1;
+}

--- a/tests/test_config_v3_migration.py
+++ b/tests/test_config_v3_migration.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _build_test_binary(tmp_path: Path) -> Path:
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+
+    binary = build_dir / "config_v3_migration"
+    sources = [
+        "tests/config_v3_migration_harness.cpp",
+        "src/config.cpp",
+    ]
+
+    command = [
+        "g++",
+        "-std=c++17",
+        "-DRIDDLEMATRIX_HOST_TEST",
+        "-Itests/stubs",
+        "-Isrc",
+        "-o",
+        str(binary),
+    ] + sources
+
+    subprocess.run(command, check=True, cwd=Path.cwd())
+    return binary
+
+
+def test_load_config_migrates_version3_layout(tmp_path) -> None:
+    binary = _build_test_binary(Path(tmp_path))
+    subprocess.run([str(binary)], check=True, cwd=Path.cwd())


### PR DESCRIPTION
## Summary
- check the former v3 config version offset (0x1D5) when reading stored EEPROM versions so v3 layouts are migrated correctly
- add a host harness and pytest covering the v3 migration path to ensure color data and flags survive the upgrade

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fb340db8f08330814cf64627af2a76