### PR TITLE
Detect EEPROM v3 config version and add migration test

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -138,7 +138,7 @@ uint16_t readStoredConfigVersion(uint16_t &versionOffset) {
     versionOffset = EEPROM_OFFSET_CONFIG_VERSION;
     EEPROM.get(EEPROM_OFFSET_CONFIG_VERSION, storedVersion);
 
-    if (isLikelyValidVersion(storedVersion)) {
+    if (storedVersion == EEPROM_CONFIG_VERSION) {
         return storedVersion;
     }
 


### PR DESCRIPTION
## Summary
- check the former v3 config version offset (0x1D5) when reading stored EEPROM versions so v3 layouts are migrated correctly
- add a host harness and pytest covering the v3 migration path to ensure color data and flags survive the upgrade
- require the new layout offset to contain the current config version before trusting it, preventing v3 trigger delay data from skipping migration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fb3b902a8483308aed09ec1ba2bad1