### PR TITLE
Absicherung des Reload-Endpunkts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,7 @@
 - `/shutdown` verlangt jetzt ein gültiges `SHUTDOWN_TOKEN` (außer bei Loopback-Anfragen), protokolliert fehlgeschlagene Versuche
   und liefert JSON-Antworten. Die Weboberfläche fragt das Token ab, bestätigt den Vorgang sichtbar und weist auf die Dauer des
   Herunterfahrens hin.
+- `/reload_all` erfordert nun dieselbe Authentifizierung wie `/shutdown` (Token oder Loopback). Die Weboberfläche blendet den
+  Button ohne gültiges Token aus, bietet einen Dialog zum Hinterlegen des Tokens, bestätigt den Vorgang zusätzlich und räumt
+  bei Fehlversuchen gespeicherte Tokens automatisch.
+- Automatisierter Flask-Test deckt sowohl den blockierten anonymen Reload als auch den erfolgreichen Token-Aufruf ab.

--- a/README.md
+++ b/README.md
@@ -147,3 +147,21 @@ Damit nur berechtigte Clients diesen Vorgang starten können, gelten seitdem fol
 
 Vor jedem Abschalten erscheint zusätzlich ein Bestätigungsdialog, damit unbeabsichtigte Klicks keine sofortige
 Abschaltung mehr auslösen. Das Frontend informiert außerdem darüber, dass der Shutdown einige Minuten dauern kann.
+
+### Geschützter Reload-All-Endpunkt
+
+Auch der Verwaltungsendpunkt `/reload_all`, der alle bekannten Boxen aus der Konfigurationsdatei löscht und über
+`dnsmasq.leases` neu erlernt, ist jetzt gegen unbefugte Zugriffe gesichert. Die Regeln entsprechen dem
+Shutdown-Endpoint:
+
+- Lokale Zugriffe (`127.0.0.1` bzw. `::1`) bleiben ohne weiteres Token erlaubt.
+- Für entfernte Clients wird derselbe Header `X-Api-Key` erwartet. Der Schlüssel wird weiterhin über die Variable
+  `SHUTDOWN_TOKEN` (z. B. in `/etc/usbstick/public_ap.env`) bereitgestellt, damit keine zusätzliche Geheimnisverwaltung
+  notwendig ist.
+- Die Weboberfläche blendet den Button „🔄 Boxen neu lernen“ aus, solange kein gültiges Token hinterlegt wurde, und
+  bietet einen separaten Dialog zum Hinterlegen des Tokens an. Vor dem Neu-Laden der Boxen erscheint zusätzlich eine
+  Sicherheitsabfrage.
+- Fehlgeschlagene Versuche führen zu HTTP 403, werden serverseitig protokolliert und löschen das gespeicherte Token im
+  Browser, damit Anwender:innen sofort eine neue Eingabe erzwingen können.
+
+Der Workflow bleibt damit kompatibel zur bestehenden Shutdown-Logik und nutzt dieselbe Konfiguration.

--- a/USBStick-Setup/files/usr/local/etc/index.html
+++ b/USBStick-Setup/files/usr/local/etc/index.html
@@ -141,39 +141,81 @@ const letterLabels = {"*": "Sun+Rad", "#": "Sun", "~": "WIFI", "&": "Rad", "?": 
 const letterOptions = "ABCDEFGHIJKLMNOPQRSTUVWXYZ*#~&?".split("");
 let currentWordTrigger = 0;
 const loopbackHosts = new Set(["localhost", "127.0.0.1", "::1"]);
-const shutdownTokenStorageKey = "shutdownToken";
+const adminTokenStorageKey = "shutdownToken";
+const sensitiveHeaderName = "X-Api-Key";
 
-function requiresShutdownToken() {
+function requiresAdminToken() {
   return !loopbackHosts.has(window.location.hostname);
 }
 
-function getStoredShutdownToken() {
-  return localStorage.getItem(shutdownTokenStorageKey) || "";
+function getStoredAdminToken() {
+  return localStorage.getItem(adminTokenStorageKey) || "";
 }
 
-function requestShutdownToken() {
-  const token = prompt("Bitte Shutdown-Token eingeben:");
+function requestAdminToken() {
+  const token = prompt("Bitte Administrations-Token eingeben:");
   if (token == null) {
     return "";
   }
   const trimmed = token.trim();
   if (trimmed) {
-    localStorage.setItem(shutdownTokenStorageKey, trimmed);
+    localStorage.setItem(adminTokenStorageKey, trimmed);
   }
   return trimmed;
 }
 
-function ensureShutdownToken() {
-  let token = getStoredShutdownToken();
+function ensureAdminToken() {
+  let token = getStoredAdminToken();
   if (token) {
     return token;
   }
-  token = requestShutdownToken();
+  token = requestAdminToken();
   return token;
 }
 
-function clearShutdownToken() {
-  localStorage.removeItem(shutdownTokenStorageKey);
+function clearAdminToken() {
+  localStorage.removeItem(adminTokenStorageKey);
+  updateReloadButtonState();
+}
+
+function isSessionAuthorized() {
+  if (!requiresAdminToken()) {
+    return true;
+  }
+  return !!getStoredAdminToken();
+}
+
+function updateReloadButtonState() {
+  const reloadButton = document.getElementById("reloadBtn");
+  if (!reloadButton) {
+    return;
+  }
+  const authorized = isSessionAuthorized();
+  reloadButton.disabled = !authorized;
+  reloadButton.title = authorized ? "" : "Authentifizierung erforderlich – Token hinterlegen";
+}
+
+function configureAdminToken() {
+  const token = requestAdminToken();
+  if (token) {
+    alert("Token gespeichert. Geschützte Aktionen wurden freigeschaltet.");
+  } else {
+    alert("Kein Token hinterlegt. Geschützte Aktionen bleiben gesperrt.");
+  }
+  updateReloadButtonState();
+}
+
+function buildSensitiveHeaders(options = { prompt: false }) {
+  const headers = {};
+  if (!requiresAdminToken()) {
+    return headers;
+  }
+  const token = options.prompt ? ensureAdminToken() : getStoredAdminToken();
+  if (!token) {
+    return null;
+  }
+  headers[sensitiveHeaderName] = token;
+  return headers;
 }
 
 function init() {
@@ -266,14 +308,17 @@ async function shutdown() {
     return;
   }
 
-  const headers = {};
-  if (requiresShutdownToken()) {
-    const token = ensureShutdownToken();
+  const headers = buildSensitiveHeaders({ prompt: true });
+  if (headers === null) {
+    alert("Herunterfahren abgebrochen – kein Token hinterlegt.");
+    return;
+  }
+  if (requiresAdminToken()) {
+    const token = headers[sensitiveHeaderName];
     if (!token) {
-      alert("Herunterfahren abgebrochen – kein Shutdown-Token angegeben.");
+      alert("Herunterfahren abgebrochen – kein Token hinterlegt.");
       return;
     }
-    headers["X-Api-Key"] = token;
   }
 
   const shutdownButton = document.getElementById("shutdown");
@@ -284,8 +329,9 @@ async function shutdown() {
   try {
     const response = await fetch("/shutdown", { method: "POST", headers });
     if (response.status === 401 || response.status === 403) {
-      clearShutdownToken();
-      alert("Authentifizierung fehlgeschlagen. Bitte Shutdown-Token prüfen.");
+      clearAdminToken();
+      alert("Authentifizierung fehlgeschlagen. Bitte Administrations-Token prüfen.");
+      updateReloadButtonState();
       return;
     }
     if (!response.ok) {
@@ -391,13 +437,15 @@ function showSetup() {
   html += `
   <div class="action-buttons">
     <button onclick="transferAll()" id="transferBtn">✅ Übertragen</button>
-    <button onclick="reloadAll()">🔄 Boxen neu lernen</button>
+    <button onclick="reloadAll()" id="reloadBtn">🔄 Boxen neu lernen</button>
+    <button onclick="configureAdminToken()" id="authBtn">🔐 Zugang hinterlegen</button>
   </div>
   <div id="statusArea"></div>
   `;
 
   document.getElementById("content").innerHTML = html;
   statusArea = document.getElementById("statusArea");
+  updateReloadButtonState();
 }
 
 function handleKeydown(event, day, word, maxLength, inputElement) {
@@ -562,8 +610,48 @@ function transferAll() {
   boxOrder.forEach(transferBox);
 }
 
-function reloadAll() {
-  fetch("/reload_all", { method: "POST" }).then(() => fetchDevices());
+async function reloadAll() {
+  if (!window.confirm("Sollen alle Boxen wirklich neu eingelesen werden?")) {
+    return;
+  }
+
+  const headers = buildSensitiveHeaders();
+  if (headers === null) {
+    alert("Vorgang abgebrochen – kein Administrations-Token hinterlegt.");
+    updateReloadButtonState();
+    return;
+  }
+
+  const reloadButton = document.getElementById("reloadBtn");
+  const originalLabel = reloadButton ? reloadButton.textContent : "";
+  if (reloadButton) {
+    reloadButton.disabled = true;
+    reloadButton.textContent = "Lade Geräte...";
+  }
+
+  try {
+    const response = await fetch("/reload_all", { method: "POST", headers });
+    if (response.status === 401 || response.status === 403) {
+      clearAdminToken();
+      alert("Authentifizierung fehlgeschlagen. Bitte Administrations-Token prüfen.");
+      return;
+    }
+    if (!response.ok) {
+      alert("Fehler beim Neu-Laden der Boxen: " + response.statusText);
+      return;
+    }
+    await fetchDevices();
+    alert("Die Boxen wurden neu eingelesen.");
+  } catch (error) {
+    console.error("Fehler beim Neu-Laden:", error);
+    alert("Netzwerkfehler beim Neu-Laden. Bitte erneut versuchen.");
+  } finally {
+    if (reloadButton) {
+      reloadButton.textContent = originalLabel || "🔄 Boxen neu lernen";
+      reloadButton.disabled = !isSessionAuthorized();
+    }
+    updateReloadButtonState();
+  }
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- schützen den Flask-Endpunkt `/reload_all` mit derselben Token-Logik wie `/shutdown`
- aktualisieren die Weboberfläche um Token-Dialog, Button-Sperren und Benutzerbestätigung
- dokumentieren das Verfahren in README/Changelog und ergänzen Tests für erlaubte und blockierte Reload-Aufrufe

## Testing
- pytest
- pytest tests/test_webserver.py::test_reload_all_blocks_unauthenticated_remote_client tests/test_webserver.py::test_reload_all_accepts_token_authenticated_client

------
https://chatgpt.com/codex/tasks/task_e_68fb5d40332483308b622672ea07956a