### PR TITLE
Schütze den Transfer-Endpunkt mit Tokenprüfung

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -550,9 +550,14 @@ def reload_all():
     get_connected_devices()
     return jsonify({"status": "reloaded"})
 
-@app.route("/transfer_box")
+@app.route("/transfer_box", methods=["POST"])
 def transfer_box():
-    hostname = request.args.get("hostname")
+    _authorize_sensitive_action("Transfer-Box")
+
+    payload = request.get_json(silent=True) or {}
+    hostname = payload.get("hostname") or request.args.get("hostname")
+    if not hostname:
+        return jsonify({"status": "❌ Hostname fehlt"}), 400
     config = load_config()
     box = config["boxen"].get(hostname)
     if not box:

--- a/USBStick-Setup/files/usr/local/etc/index.html
+++ b/USBStick-Setup/files/usr/local/etc/index.html
@@ -585,6 +585,13 @@ function removeBox(hostname) {
 }
 
 async function transferBox(hostname) {
+  const headers = buildSensitiveHeaders({ prompt: true });
+  if (headers === null) {
+    alert("Übertragung abgebrochen – kein Administrations-Token hinterlegt.");
+    return;
+  }
+  headers["Content-Type"] = "application/json";
+
   transferQueue[hostname] = true;
   const transferBtn = document.getElementById("transferBtn");
   if (!transferring) {
@@ -592,18 +599,42 @@ async function transferBox(hostname) {
     transferBtn.disabled = true;
     transferBtn.innerText = "Übertrage...";
   }
-  const response = await fetch(`/transfer_box?hostname=${hostname}`);
-  const data = await response.json();
-  delete transferQueue[hostname];
-  if (Object.keys(transferQueue).length === 0) {
-    transferring = false;
-    transferBtn.disabled = false;
-    transferBtn.innerText = "✅ Übertragen";
+
+  let statusText = "❌ Unbekannter Fehler";
+
+  try {
+    const response = await fetch("/transfer_box", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ hostname })
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      clearAdminToken();
+      statusText = "❌ Zugriff verweigert";
+    } else if (!response.ok) {
+      statusText = `❌ Fehler (${response.status})`;
+    } else {
+      const data = await response.json();
+      statusText = data.status || "❌ Unerwartete Antwort";
+    }
+  } catch (error) {
+    console.error("Fehler beim Übertragen:", error);
+    statusText = "❌ Netzwerkfehler";
+  } finally {
+    delete transferQueue[hostname];
+    if (Object.keys(transferQueue).length === 0) {
+      transferring = false;
+      transferBtn.disabled = false;
+      transferBtn.innerText = "✅ Übertragen";
+    }
+    statusArea.innerHTML += `<div class="statusEntry">${hostname}: ${statusText}</div>`;
+    setTimeout(() => {
+      if (statusArea.firstChild) {
+        statusArea.removeChild(statusArea.firstChild);
+      }
+    }, 3000);
   }
-  statusArea.innerHTML += `<div class="statusEntry">${hostname}: ${data.status}</div>`;
-  setTimeout(() => {
-    statusArea.removeChild(statusArea.firstChild);
-  }, 3000);
 }
 
 function transferAll() {


### PR DESCRIPTION
## Zusammenfassung
- erzwinge eine Token- bzw. Loopback-Prüfung für den Endpunkt `/transfer_box` und lehne fehlende Hostnamen ab
- passe das Frontend an, sodass Übertragungen per POST mit Token-Header erfolgen
- erweitere die Tests um Autorisierungsszenarien und passe bestehende Fälle an

## Tests
- pytest tests/test_webserver.py

------
https://chatgpt.com/codex/tasks/task_e_68fb61b758b0833095c97e0032a4ead7