### PR TITLE
Schutz für Remove-Box-Route und Frontend-Token-Handling

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -519,7 +519,9 @@ def update_box():
 
 @app.route("/remove_box", methods=["POST"])
 def remove_box():
-    data = request.json
+    _authorize_sensitive_action("Remove-Box")
+
+    data = request.get_json(silent=True) or {}
     hostname = data.get("hostname")
     config = load_config()
     if hostname in config["boxen"]:

--- a/USBStick-Setup/files/usr/local/etc/index.html
+++ b/USBStick-Setup/files/usr/local/etc/index.html
@@ -568,11 +568,32 @@ function saveBoxOrder() {
 }
 
 function removeBox(hostname) {
+  const headers = buildSensitiveHeaders({ prompt: true });
+  if (headers === null) {
+    const message = '⚠️ Entfernen abgebrochen – Administrations-Token erforderlich.';
+    if (statusArea) {
+      statusArea.innerHTML = `<div class="statusEntry status">${message}</div>`;
+    }
+    alert(message);
+    return;
+  }
+
+  headers["Content-Type"] = "application/json";
+
   fetch("/remove_box", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({ hostname })
   }).then(response => {
+    if (response.status === 401 || response.status === 403) {
+      clearAdminToken();
+      const message = '❌ Zugriff verweigert – bitte Token prüfen.';
+      if (statusArea) {
+        statusArea.innerHTML = `<div class="statusEntry status">${message}</div>`;
+      }
+      alert(message);
+      return;
+    }
     if (!response.ok) {
       statusArea.innerHTML = '<div class="statusEntry status">❌ Fehler beim Entfernen.</div>';
     } else {


### PR DESCRIPTION
## Summary
- schützen des /remove_box-Endpunkts durch zentrale Autorisierung und robustes JSON-Parsing
- Erweiterung des Frontends um Token-Header, Hinweis bei fehlender Session und Fehlerbehandlung
- Ergänzung von Tests für entfernte Boxen ohne und mit gültigem Token, inklusive Aktualisierung der boxOrder

## Testing
- pytest tests/test_webserver.py *(wird übersprungen, da Flask im Testumfeld fehlt)*

------
https://chatgpt.com/codex/tasks/task_e_68fb9550dc248330b544f5980ca5a148