### PR TITLE
Harte Rechte für dnsmasq-Leases in Hotspot-Skripten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@
 - `setup.sh` setzt die Lease-Datei `var/lib/misc/dnsmasq.leases` nun mit Eigentümer `root:dnsmasq` auf `0640`, legt sie bei
   Bedarf idempotent an und dokumentiert die Abhängigkeit vom Dienstkonto, damit `dnsmasq` trotz restriktiver Rechte weiterhin
   startet.
+- `bootlocal.sh` und `install_public_ap.sh` verwenden dieselben restriktiven Rechte für `dnsmasq.leases`, prüfen auf das
+  Vorhandensein der `dnsmasq`-Gruppe und fallen bei Bedarf auf `root:root` zurück; Testlauf beider Skripte bestätigt via
+  `ls -l /var/lib/misc/dnsmasq.leases` die erwarteten Besitzer/Rechte.

--- a/USBStick-Setup/files/root/install_public_ap.sh
+++ b/USBStick-Setup/files/root/install_public_ap.sh
@@ -37,8 +37,19 @@ public_ap_write_dnsmasq_config "$WIFI_IFACE"
 public_ap_render_hostapd_config "$WIFI_IFACE"
 
 mkdir -p /var/lib/misc
-touch /var/lib/misc/dnsmasq.leases
-chmod 777 /var/lib/misc/dnsmasq.leases
+LEASES_FILE="/var/lib/misc/dnsmasq.leases"
+LEASES_USER="root"
+LEASES_GROUP="dnsmasq"
+if ! getent group "$LEASES_GROUP" >/dev/null 2>&1; then
+    echo "⚠️ Gruppe $LEASES_GROUP nicht vorhanden; verwende root:root für $LEASES_FILE" >&2
+    LEASES_GROUP="$LEASES_USER"
+fi
+if [[ -e "$LEASES_FILE" ]]; then
+    chmod 0640 "$LEASES_FILE"
+else
+    install -o "$LEASES_USER" -g "$LEASES_GROUP" -m 0640 /dev/null "$LEASES_FILE"
+fi
+chown "$LEASES_USER:$LEASES_GROUP" "$LEASES_FILE"
 
 systemctl restart hostapd
 systemctl restart dnsmasq

--- a/USBStick-Setup/files/usr/local/bin/bootlocal.sh
+++ b/USBStick-Setup/files/usr/local/bin/bootlocal.sh
@@ -43,8 +43,19 @@ public_ap_write_dnsmasq_config "$WIFI_IFACE"
 public_ap_render_hostapd_config "$WIFI_IFACE"
 
 mkdir -p /var/lib/misc
-touch /var/lib/misc/dnsmasq.leases
-chmod 777 /var/lib/misc/dnsmasq.leases
+LEASES_FILE="/var/lib/misc/dnsmasq.leases"
+LEASES_USER="root"
+LEASES_GROUP="dnsmasq"
+if ! getent group "$LEASES_GROUP" >/dev/null 2>&1; then
+    echo "⚠️ Gruppe $LEASES_GROUP nicht vorhanden; verwende root:root für $LEASES_FILE" >&2
+    LEASES_GROUP="$LEASES_USER"
+fi
+if [[ -e "$LEASES_FILE" ]]; then
+    chmod 0640 "$LEASES_FILE"
+else
+    install -o "$LEASES_USER" -g "$LEASES_GROUP" -m 0640 /dev/null "$LEASES_FILE"
+fi
+chown "$LEASES_USER:$LEASES_GROUP" "$LEASES_FILE"
 
 systemctl restart hostapd
 systemctl restart dnsmasq


### PR DESCRIPTION
## Zusammenfassung
- richte in bootlocal.sh und install_public_ap.sh ein, dass dnsmasq.leases mit 0640 und Besitzer root:dnsmasq (Fallback root:root) angelegt bzw. korrigiert wird
- ergänze eine Gruppenprüfung für dnsmasq und protokolliere den Fallback auf root:root
- dokumentiere die Tests im Changelog

## Tests
- PATH="/tmp/testbin:$PATH" bash USBStick-Setup/files/usr/local/bin/bootlocal.sh
- PATH="/tmp/testbin:$PATH" bash USBStick-Setup/files/root/install_public_ap.sh
- ls -l /var/lib/misc/dnsmasq.leases


------
https://chatgpt.com/codex/tasks/task_e_68fbdd4c6c188330b4eaeb78efa68eea