### PR TITLE
Härtung der IP-Validierung und Frontend-Anzeige

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@
 - `bootlocal.sh` und `install_public_ap.sh` verwenden dieselben restriktiven Rechte für `dnsmasq.leases`, prüfen auf das
   Vorhandensein der `dnsmasq`-Gruppe und fallen bei Bedarf auf `root:root` zurück; Testlauf beider Skripte bestätigt via
   `ls -l /var/lib/misc/dnsmasq.leases` die erwarteten Besitzer/Rechte.
+- Flask-Webserver prüft und normalisiert IPv4-Adressen konsequent (inkl. `devices`-Antworten), ersetzt manipulierte Eingaben
+  durch den Platzhalter `0.0.0.0`, erzeugt `<iframe>`-Elemente nur noch per DOM-API und wird durch einen neuen Regressionstest
+  gegen bösartige IP-Strings abgesichert.

--- a/USBStick-Setup/files/usr/local/etc/index.html
+++ b/USBStick-Setup/files/usr/local/etc/index.html
@@ -385,7 +385,13 @@ function renderDeviceList() {
 }
 
 function openBox(ip) {
-  document.getElementById("content").innerHTML = `<iframe src="http://${ip}"></iframe>`;
+  const container = document.getElementById("content");
+  while (container.firstChild) {
+    container.removeChild(container.firstChild);
+  }
+  const iframe = document.createElement("iframe");
+  iframe.src = `http://${ip}`;
+  container.appendChild(iframe);
 }
 
 async function shutdown() {


### PR DESCRIPTION
## Zusammenfassung
- validiert IPv4-Adressen im Flask-Webserver robust mit Platzhalter-Rückfall und normalisiert bestehende Konfigurationseinträge
- aktualisiert die Geräteansicht, damit Iframes ausschließlich per DOM-API erzeugt werden
- ergänzt einen Regressionstest für manipulierte IP-Eingaben und dokumentiert die Anpassungen im Changelog

## Tests
- pytest tests/test_webserver.py

------
https://chatgpt.com/codex/tasks/task_e_68fc01574e688330a808ab732b1c4e34