### PR TITLE
Fix load_config to recover from non-dict payloads

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -40,9 +40,18 @@ def _default_config():
     return {"boxen": {}, "boxOrder": []}
 
 def load_config():
+    changed = False
     try:
         with open(CONFIG_FILE, "r") as f:
             data = json.load(f)
+        if not isinstance(data, dict):
+            app.logger.warning(
+                "Konfigurationsdatei %s enthält unerwarteten Typ (%s) – Standardwerte werden verwendet",
+                CONFIG_FILE,
+                type(data).__name__,
+            )
+            data = _default_config()
+            changed = True
     except (json.JSONDecodeError, OSError) as exc:
         app.logger.warning(
             "Konfigurationsdatei %s defekt – Standardwerte werden verwendet: %s",
@@ -52,7 +61,6 @@ def load_config():
         data = _default_config()
         save_config(data)
 
-    changed = False
     if migrate_config(data):
         changed = True
     if _normalize_config_ips(data):

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -56,6 +56,18 @@ def test_load_config_recovers_from_corrupted_file(tmp_path):
     assert json.loads(config_path.read_text(encoding="utf-8")) == module._default_config()
 
 
+@pytest.mark.parametrize("payload", [[], None])
+def test_load_config_repairs_non_dict_payload(tmp_path, payload):
+    module = _load_webserver(tmp_path)
+    config_path = Path(module.CONFIG_FILE)
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    data = module.load_config()
+
+    assert data == module._default_config()
+    assert json.loads(config_path.read_text(encoding="utf-8")) == module._default_config()
+
+
 def test_get_hostname_from_web_supports_attribute_variants(webserver_app, monkeypatch):
     module, _client = webserver_app
 


### PR DESCRIPTION
## Summary
- ensure load_config replaces non-dict payloads with the default configuration and persists the fix
- reuse the shared default configuration helper when repairing corrupted payloads
- add regression coverage that verifies list/null payloads are normalized to the default config

## Testing
- pytest tests/test_webserver.py -k load_config

------
https://chatgpt.com/codex/tasks/task_e_68fc051a5dac8330b342a980513a3b3b