### PR TITLE
Allow empty WiFi passwords and add test

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -386,11 +386,13 @@ void loadConfig() {
     bool wifiPasswordHasNonPrintable = containsNonPrintable(wifi_password, sizeof(wifi_password));
     bool wifiPasswordHasFF = contains0xFF(wifi_password, sizeof(wifi_password));
 
-    if (wifiPasswordHasFF || wifiPasswordEmpty || wifiPasswordWhitespaceOnly || wifiPasswordHasNonPrintable) {
+    if (wifiPasswordHasFF || wifiPasswordWhitespaceOnly || wifiPasswordHasNonPrintable) {
         Serial.println(F("🛑 Ungültiges WiFi-Passwort im EEPROM gefunden! Setze Standardwert..."));
         strncpy(wifi_password, DEFAULT_WIFI_PASSWORD, sizeof(wifi_password));
         wifi_password[sizeof(wifi_password) - 1] = '\0';
         eepromUpdated = true;
+    } else if (wifiPasswordEmpty) {
+        Serial.println(F("ℹ️ Leeres WiFi-Passwort erkannt – offene Netzwerke werden unterstützt."));
     }
 
     size_t hostnameLength = strnLength(hostname, sizeof(hostname));


### PR DESCRIPTION
## Summary
- accept intentionally empty WiFi passwords while keeping other sanitization rules
- log that open networks are supported when an empty password is loaded
- extend the host-side sanitization harness to cover EEPROM entries with an empty password

## Testing
- pytest tests/test_config_sanitization.py

------
https://chatgpt.com/codex/tasks/task_e_68fc094342248330b17e6c4290cadc80