### PR TITLE
Absicherung von Loopback-Ausnahmen bei Proxy-Headern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - `/shutdown` verlangt jetzt ein gültiges `SHUTDOWN_TOKEN` (außer bei Loopback-Anfragen), protokolliert fehlgeschlagene Versuche
   und liefert JSON-Antworten. Die Weboberfläche fragt das Token ab, bestätigt den Vorgang sichtbar und weist auf die Dauer des
   Herunterfahrens hin.
+- Loopback-Ausnahmen akzeptieren nur noch eindeutig lokale Verbindungswege; sobald `X-Forwarded-For` oder `Forwarded`
+  nicht ausschließlich Loopback-Adressen enthalten, ist zwingend ein gültiger Administrations-Token erforderlich.
 - `/reload_all` erfordert nun dieselbe Authentifizierung wie `/shutdown` (Token oder Loopback). Die Weboberfläche blendet den
   Button ohne gültiges Token aus, bietet einen Dialog zum Hinterlegen des Tokens, bestätigt den Vorgang zusätzlich und räumt
   bei Fehlversuchen gespeicherte Tokens automatisch.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Damit nur berechtigte Clients diesen Vorgang starten können, gelten seitdem fol
   auf „Herunterfahren“ ab, speichert es im Browser und übermittelt es anschließend per HTTP-Header `X-Api-Key`.
 - Ungültige oder fehlende Tokens führen zu HTTP 403. Der Browser blendet in diesem Fall einen Hinweis ein und verlangt
   bei Bedarf die erneute Eingabe.
+- Reverse-Proxies oder HTTP-Weiterleitungen müssen künftig den gültigen Administrations-Token weiterreichen. Anfragen,
+  deren `X-Forwarded-For`- oder `Forwarded`-Header nicht ausschließlich lokale (`127.0.0.1`/`::1`) Stationen enthalten,
+  werden ohne Token konsequent mit HTTP 403 beantwortet.
 
 Vor jedem Abschalten erscheint zusätzlich ein Bestätigungsdialog, damit unbeabsichtigte Klicks keine sofortige
 Abschaltung mehr auslösen. Das Frontend informiert außerdem darüber, dass der Shutdown einige Minuten dauern kann.
@@ -177,5 +180,7 @@ Shutdown-Endpoint:
   Sicherheitsabfrage.
 - Fehlgeschlagene Versuche führen zu HTTP 403, werden serverseitig protokolliert und löschen das gespeicherte Token im
   Browser, damit Anwender:innen sofort eine neue Eingabe erzwingen können.
+- Auch hier gilt: Proxy-Ketten mit externen Hops müssen ein gültiges `X-Api-Key`-Token beilegen. Reine Loopback-Hop-Ketten
+  bleiben ohne Token zulässig.
 
 Der Workflow bleibt damit kompatibel zur bestehenden Shutdown-Logik und nutzt dieselbe Konfiguration.


### PR DESCRIPTION
## Summary
- sichern sensible Aktionen gegen manipulierte Forwarded-Header ab und werten vollständige Proxy-Ketten aus
- ergänzen Regressionstests für Loopback-Aufrufe mit und ohne Forwarded-Header
- dokumentieren die neuen Anforderungen für Administratoren im Changelog und in der README

## Testing
- pytest tests/test_webserver.py

------
https://chatgpt.com/codex/tasks/task_e_68fc53b5501083308dd63c24c1e6897c