### PR TITLE
Fix displayLetter handling for Sun+Rad glyph

### DIFF
--- a/src/trigger_handler.cpp
+++ b/src/trigger_handler.cpp
@@ -247,12 +247,6 @@ bool displayLetter(uint8_t triggerIndex, char letter) {
 
     triggerActive = true;
 
-    if (letter == '*') {
-        letter = (random(2) == 0) ? '#' : '&';
-        Serial.print(F("🔀 `*` wurde ersetzt durch: "));
-        Serial.println(letter);
-    }
-
     int today = getRTCWeekday();
     Serial.print(F("📅 Heutiger Wochentag: "));
     Serial.println(today);


### PR DESCRIPTION
## Summary
- remove the legacy randomization that replaced the '*' glyph before rendering so the Sun+Rad bitmap can be shown

## Testing
- pytest tests/test_letters_sunplusrad.py

------
https://chatgpt.com/codex/tasks/task_e_68fc605290a083309d6afc7f9b75b970