### PR TITLE
Add authentication checks for letter endpoints

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -1567,6 +1567,9 @@ void setupWebServer() {
 
     server.on("/displayLetter", HTTP_GET, [](AsyncWebServerRequest *request) {
         refreshWiFiIdleTimer(F("GET /displayLetter"));
+        if (!ensureAuthenticated(request, F("GET /displayLetter"))) {
+            return;
+        }
         if (!request->hasParam("char")) {
             request->send(400, "text/plain", "Fehlender Parameter!");
             return;
@@ -1625,6 +1628,9 @@ void setupWebServer() {
 
     server.on("/triggerLetter", HTTP_GET, [](AsyncWebServerRequest *request) {
         refreshWiFiIdleTimer(F("GET /triggerLetter"));
+        if (!ensureAuthenticated(request, F("GET /triggerLetter"))) {
+            return;
+        }
         uint8_t triggerIndex = 0;
         if (request->hasParam("trigger")) {
             int triggerValue = request->getParam("trigger")->value().toInt();


### PR DESCRIPTION
## Summary
- require authentication for the /displayLetter handler before processing parameters
- guard the /triggerLetter handler with the same authentication check to keep behavior consistent with other protected endpoints

## Testing
- `platformio run` *(fails: platformio: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fd555fe734833092a8cb4c95de9b67