### PR TITLE
Update Dokumentation zur Sicherheitsstrategie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
   gegen bösartige IP-Strings abgesichert.
 - Neues 32×32-Bitmap „Sun+Rad“ (`'*'`) kombiniert Sonne und Riesenrad, wird in `loadLetterData()` registriert und besitzt einen
   Host-Test, der Mapping und aktive Pixel verifiziert.
+- **2024-05-21 – Dokumentationsupdate:** README und TODO beschreiben nun das Offline-Sicherheitskonzept mit temporärem WLAN-Fenster ohne Token-Authentifizierung; dieses Zielbild soll unverändert bestehen bleiben.

--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ Siehe [TODO.md](TODO.md) für den Projektfahrplan.
 2. Firmware kompilieren und hochladen.
 3. Nach erfolgreicher Verbindung `http://<hostname>` aufrufen und die Zugangsdaten im EEPROM speichern.
 
-### Token-basierter Administrationsschutz
+### Token-basierter Administrationsschutz (historisch)
 
-- In der Weboberfläche befindet sich jetzt der Abschnitt **API-Sicherheit**.
-- Ein aktivierter Schutz verlangt bei allen konfigurationsändernden Routen (z. B. `/updateWiFi`, `/updateDisplaySettings`, `/updateTriggerDelays`, `/updateAllLetters`, `/setTime`, `/syncNTP` und `/updateAuth`) ein Token.
-- Tokens müssen mindestens `AUTH_TOKEN_MIN_LENGTH` Zeichen lang sein (derzeit 12), ausschließlich druckbare ASCII-Zeichen enthalten und werden im EEPROM abgelegt.
-- Browserseitig reicht es, das Token im Feld „Token für diese Sitzung“ einzutragen. Das Frontend übermittelt es automatisch als Header `X-Auth-Token` und zusätzlich als Formularfeld `auth_token`.
-- Skripte oder externe Clients können denselben Header oder den Query-/Body-Parameter `auth_token` verwenden.
-- Wird der Schutz deaktiviert, entfernt die Firmware das gespeicherte Token konsequent aus dem EEPROM.
+- Die frühere Token-Mechanik bleibt als historische Referenz im Code und in der Weboberfläche dokumentiert, ist jedoch dauerhaft deaktiviert.
+- Ein erneutes Aktivieren ist ausdrücklich **nicht vorgesehen**; bitte diese Funktion nicht wieder einschalten, um das aktuelle Sicherheitskonzept nicht zu verwässern.
+- Der WLAN-Zugang des Systems steht ausschließlich in einem kurzen Zeitfenster direkt nach dem Neustart zur Verfügung. Sobald die anfängliche Konfigurationsphase abgeschlossen ist, schaltet die Firmware das Funkmodul ab und arbeitet dauerhaft offline.
+- Bereits im EEPROM hinterlegte Tokens werden nicht mehr ausgewertet. Beim Booten entfernt die Firmware sie weiterhin, damit keine Altbestände aktiv bleiben.
+
+## Sicherheitsstrategie
+
+RiddleMatrix wird ausschließlich über das temporäre WLAN-Fenster unmittelbar nach einem Neustart administriert. Danach bleibt das Gerät vollständig offline; eine Passwort-, Token- oder sonstige Authentifizierungslogik ist bewusst nicht vorgesehen. Bitte dieses Konzept unverändert beibehalten, damit der Angriffsradius minimal bleibt und die Wartungsabläufe konsistent bleiben.
 
 ## Kompilieren und Hochladen
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,13 +14,13 @@ Diese Datei enthält eine Übersicht offener und bereits umgesetzter Aufgaben f�
 - [x] Automatische Buchstabenausgabe in festen Intervallen
 - [x] Mehrspurige Tageskonfiguration (Buchstaben & Farben pro Triggerleitung)
 - [x] Weboberfläche für WLAN‑Daten, Anzeigeparameter und RTC‑Zeit
-- [x] Web‑UI absichern (Authentifizierung, Schutzmechanismen)
+- [x] Web‑UI absichern (Authentifizierung, Schutzmechanismen) – historische Token-Implementierung, bleibt deaktiviert (siehe README)
 - [x] WiFi‑Symbolanzeige und automatisches Abschalten des Webservers bei Verbindungsverlust
 - [x] EEPROM‑Speicherung aller Einstellungen inklusive Farben je Wochentag
 - [x] CI aufsetzen, die den Arduino‑Code baut
 - [x] Zeitsynchronisation per NTP
 
 ## Ergänzende Ideen
-- [ ] Authentifizierungsoptionen (Passwortschutz oder OAuth)
+- [ ] Authentifizierungsoptionen (Passwortschutz oder OAuth) – verworfen, keine zusätzliche Authentifizierung mehr vorgesehen
 - [ ] Upload eigener Bitmaps zum Erweitern der Buchstaben/Symbole
 - [ ] Weitere Triggerquellen (z.B. HTTP‑API oder MQTT)


### PR DESCRIPTION
## Summary
- kennzeichnet den tokenbasierten Administrationsschutz als historische, deaktivierte Funktion und beschreibt den Offline-Betrieb
- ergänzt einen Abschnitt zur Sicherheitsstrategie und bittet darum, das temporäre WLAN-Fenster unverändert zu lassen
- vermerkt in TODO und CHANGELOG den Verzicht auf zukünftige Authentifizierungsmechanismen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd5cc75c5c8330b740413ff5c03983