### PR TITLE
Ensure display brightness updates refresh WiFi symbol

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -1015,6 +1015,10 @@ void setupWebServer() {
         }
 
         display_brightness = static_cast<int>(brightnessCandidate);
+        display.setBrightness(display_brightness);
+        if (!triggerActive && wifiSymbolVisible) {
+            display.display();
+        }
         letter_display_time = letterTimeCandidate;
         letter_auto_display_interval = autoIntervalCandidate;
         autoDisplayMode = autoModeCandidate;


### PR DESCRIPTION
## Summary
- call `display.setBrightness` when applying new brightness from the web UI
- refresh the WiFi status symbol when brightness changes while the matrix is idle

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fdd9b0ee5483309c18fdad3b0fd2e9