### PR TITLE
Fix web server running flag when disabling WiFi via serial trigger

### DIFF
--- a/src/trigger_handler.cpp
+++ b/src/trigger_handler.cpp
@@ -344,6 +344,7 @@ void handleTrigger(char triggerType, bool isAutoMode, bool fromWeb) {
             WiFi.disconnect();
             wifiConnected = false;
             server.end();
+            webServerRunning = false;
         } else {
             Serial.print(F("ℹ️ WiFi bleibt aktiv (Quelle: "));
             if (isAutoMode) {


### PR DESCRIPTION
## Summary
- ensure the web server status flag is cleared when a serial trigger disconnects WiFi

## Testing
- not run (hardware-dependent manual validation required)


------
https://chatgpt.com/codex/tasks/task_e_68fdda7801ac83309a1321944b3bade7