### PR TITLE
Remove unused admin token button

### DIFF
--- a/USBStick-Setup/files/usr/local/etc/index.html
+++ b/USBStick-Setup/files/usr/local/etc/index.html
@@ -380,7 +380,6 @@ function showSetup() {
   <div class="action-buttons">
     <button onclick="transferAll()" id="transferBtn">✅ Übertragen</button>
     <button onclick="reloadAll()" id="reloadBtn">🔄 Boxen neu lernen</button>
-    <button onclick="configureAdminToken()" id="authBtn">🔐 Zugang hinterlegen</button>
   </div>
   <div id="statusArea"></div>
   `;


### PR DESCRIPTION
## Summary
- remove the unused admin token button from the action button block
- ensure only the transfer and reload buttons remain in the interface

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe173d86288330abd1e515cb08fcb2