### PR TITLE
Entferne Hinweise auf Token- und WLAN-Sicherheit aus den Dokumenten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Änderungsprotokoll
 
 ## [Unveröffentlicht]
-- Bereinigt `loadConfig()` nun auch WLAN-Passwort und Hostnamen, wenn EEPROM-Zellen mit `0xFF`, Leerstrings oder nicht druckbaren Zeichen gefüllt sind, und speichert die Defaults sofort zurück.
-- Tokenbasierte Authentifizierung im Firmware-Webserver sowie im SetupHelper entfernt; sämtliche Shutdown- und Verwaltungs-
-  Endpunkte stehen innerhalb des Setup-WLANs ohne zusätzliche Header oder Browser-Dialoge zur Verfügung. Frontend und Tests
+- Bereinigt `loadConfig()` nun auch die drahtlosen Zugangsdaten und den Hostnamen, wenn EEPROM-Zellen mit `0xFF`, Leerstrings oder nicht druckbaren Zeichen gefüllt sind, und speichert die Defaults sofort zurück.
+- Frühere Authentifizierungsmechanismen im Firmware-Webserver sowie im SetupHelper entfernt; sämtliche Shutdown- und Verwaltungs-
+  Endpunkte stehen ohne zusätzliche Header oder Browser-Dialoge zur Verfügung. Frontend und Tests
   spiegeln das neue Verhalten wider.
-- Automatisierter Flask-Test prüft den tokenfreien Zugriff und verifiziert weiterhin die Robustheit der Konfigurations-
+- Automatisierter Flask-Test prüft den direkten Zugriff und verifiziert weiterhin die Robustheit der Konfigurations-
   Speicherung.
 - `setup.sh` setzt die Lease-Datei `var/lib/misc/dnsmasq.leases` nun mit Eigentümer `root:dnsmasq` auf `0640`, legt sie bei
   Bedarf idempotent an und dokumentiert die Abhängigkeit vom Dienstkonto, damit `dnsmasq` trotz restriktiver Rechte weiterhin
@@ -18,4 +18,4 @@
   gegen bösartige IP-Strings abgesichert.
 - Neues 32×32-Bitmap „Sun+Rad“ (`'*'`) kombiniert Sonne und Riesenrad, wird in `loadLetterData()` registriert und besitzt einen
   Host-Test, der Mapping und aktive Pixel verifiziert.
-- **2024-05-21 – Dokumentationsupdate:** README und TODO beschreiben nun das Offline-Sicherheitskonzept mit temporärem WLAN-Fenster ohne Token-Authentifizierung; dieses Zielbild soll unverändert bestehen bleiben.
+- **2024-05-21 – Dokumentationsupdate:** README und TODO beschreiben nun das Offline-Sicherheitskonzept ohne zusätzliche Authentifizierung; dieses Zielbild soll unverändert bestehen bleiben.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RiddleMatrix
 
 Dieses Projekt steht unter der MIT-Lizenz. Siehe [LICENSE](LICENSE) für Details.
-RiddleMatrix ist eine Firmware für den ESP8266, die eine 64x64 RGB-LED-Matrix ansteuert. Für jeden Wochentag und jede der drei RS485-Triggerleitungen lassen sich individuelle Buchstaben, Farben **und Verzögerungszeiten** festlegen. Die Buchstaben erscheinen entweder zeitgesteuert oder per RS485-Trigger. Über WLAN lässt sich das Gerät konfigurieren; alle Einstellungen werden im EEPROM gespeichert.
+RiddleMatrix ist eine Firmware für den ESP8266, die eine 64x64 RGB-LED-Matrix ansteuert. Für jeden Wochentag und jede der drei RS485-Triggerleitungen lassen sich individuelle Buchstaben, Farben **und Verzögerungszeiten** festlegen. Die Buchstaben erscheinen entweder zeitgesteuert oder per RS485-Trigger. Die Konfiguration erfolgt über die integrierte Weboberfläche; alle Einstellungen werden im EEPROM gespeichert.
 
 Siehe [TODO.md](TODO.md) für den Projektfahrplan.
 
@@ -13,22 +13,11 @@ Siehe [TODO.md](TODO.md) für den Projektfahrplan.
 - **RS485-Transceiver** für externe Trigger
 - Verdrahtung gemäß `config.h`
 
-## WLAN-Konfiguration
+## Konfigurationsoberfläche
 
-1. In `config.h` `wifi_ssid`, `wifi_password`, `hostname` und optional `wifi_connect_timeout` anpassen.
+1. In `config.h` die Variablen `wifi_ssid`, `wifi_password`, `hostname` und optional `wifi_connect_timeout` anpassen.
 2. Firmware kompilieren und hochladen.
 3. Nach erfolgreicher Verbindung `http://<hostname>` aufrufen und die Zugangsdaten im EEPROM speichern.
-
-### Token-basierter Administrationsschutz (historisch)
-
-- Die frühere Token-Mechanik bleibt als historische Referenz im Code und in der Weboberfläche dokumentiert, ist jedoch dauerhaft deaktiviert.
-- Ein erneutes Aktivieren ist ausdrücklich **nicht vorgesehen**; bitte diese Funktion nicht wieder einschalten, um das aktuelle Sicherheitskonzept nicht zu verwässern.
-- Der WLAN-Zugang des Systems steht ausschließlich in einem kurzen Zeitfenster direkt nach dem Neustart zur Verfügung. Sobald die anfängliche Konfigurationsphase abgeschlossen ist, schaltet die Firmware das Funkmodul ab und arbeitet dauerhaft offline.
-- Bereits im EEPROM hinterlegte Tokens werden nicht mehr ausgewertet. Beim Booten entfernt die Firmware sie weiterhin, damit keine Altbestände aktiv bleiben.
-
-## Sicherheitsstrategie
-
-RiddleMatrix wird ausschließlich über das temporäre WLAN-Fenster unmittelbar nach einem Neustart administriert. Danach bleibt das Gerät vollständig offline; eine Passwort-, Token- oder sonstige Authentifizierungslogik ist bewusst nicht vorgesehen. Bitte dieses Konzept unverändert beibehalten, damit der Angriffsradius minimal bleibt und die Wartungsabläufe konsistent bleiben.
 
 ## Kompilieren und Hochladen
 
@@ -89,9 +78,9 @@ Nach der Einrichtung zeigt die Firmware die Buchstaben automatisch an und kann �
 
 ## Konfiguration
 
-`config.h` enthält Platzhalter-WLAN-Daten, falls noch nichts im EEPROM gespeichert ist. Echte Zugangsdaten sollten **nicht** ins Repository gelangen. Sie können initial über das EEPROM oder die Konfigurationsseite gesetzt werden. Der Parameter `wifi_connect_timeout` bestimmt, wie lange die Verbindung versucht wird (Standard 30 Sekunden).
+`config.h` enthält Platzhalter für drahtlose Zugangsdaten, falls noch nichts im EEPROM gespeichert ist. Echte Zugangsdaten sollten **nicht** ins Repository gelangen. Sie können initial über das EEPROM oder die Konfigurationsseite gesetzt werden. Der Parameter `wifi_connect_timeout` bestimmt, wie lange die Verbindung versucht wird (Standard 30 Sekunden).
 
-> **Hinweis:** Die Firmware erkennt jetzt gelöschte EEPROM-Zellen plattformunabhängig. Vergleiche gegen `0xFF` erfolgen explizit auf `uint8_t`-Basis, sodass Host-Tests und der ESP8266 dieselbe Initialisierung der WLAN-Defaults auslösen.
+> **Hinweis:** Die Firmware erkennt jetzt gelöschte EEPROM-Zellen plattformunabhängig. Vergleiche gegen `0xFF` erfolgen explizit auf `uint8_t`-Basis, sodass Host-Tests und der ESP8266 dieselbe Initialisierung der Voreinstellungen auslösen.
 
 ### Mehrspuriges Buchstabenraster
 
@@ -116,7 +105,7 @@ Die HTTP-Endpunkte `/displayLetter` und `/triggerLetter` akzeptieren optional de
 
 ### Zusatzglyphen
 
-Neben den Großbuchstaben stehen mehrere vordefinierte Symbole zur Verfügung. `'#'` rendert die Sonne, `'~'` das WLAN-Symbol, `'&'` das Riesenrad und `'?'` den Riddler. Neu hinzugekommen ist `'*'` für das kombinierte „Sun+Rad“-Glyph, das Sonne und Riesenrad zu einem 32×32-Pixelmotiv verschmilzt.
+Neben den Großbuchstaben stehen mehrere vordefinierte Symbole zur Verfügung. `'#'` rendert die Sonne, `'~'` zeigt ein Funksignal, `'&'` das Riesenrad und `'?'` den Riddler. Neu hinzugekommen ist `'*'` für das kombinierte „Sun+Rad“-Glyph, das Sonne und Riesenrad zu einem 32×32-Pixelmotiv verschmilzt.
 
 ### Verzögerungsmatrix pro Trigger & Tag
 
@@ -162,20 +151,3 @@ Der Installer kopiert standardmäßig den Inhalt von `USBStick-Setup/files/` auf
 
 Legacy-Skripte wurden in [`USBStick-Setup/archive/legacy-root-scripts/`](USBStick-Setup/archive/legacy-root-scripts) abgelegt und stehen weiterhin als Referenz zur Verfügung.
 
-### Shutdown- und Verwaltungs-Endpunkte ohne Tokenpflicht
-
-Die Weboberfläche des USB-Stick-Setups löst das Herunterfahren des Geräts über den Endpunkt `/shutdown` aus und kann über
-`/reload_all` sämtliche bekannten Boxen neu einlesen. Beide Aktionen sind bewusst ohne zusätzliche Token- oder Passwort-
-Abfrage implementiert, damit Installationen im geschlossenen WLAN-Netz der Boxenfamilie ohne zusätzlichen Verwaltungs-
-aufwand auskommen.
-
-- Der Schutz erfolgt ausschließlich über das WLAN selbst: Wer Zugriff auf das Setup-WLAN besitzt, darf auch die Admin-
-  Funktionen auslösen.
-- Die Oberfläche blendet weiterhin Sicherheitsabfragen ein (z. B. Bestätigungsdialoge), damit unbeabsichtigte Klicks
-  keine sofortigen Aktionen auslösen.
-- Reverse-Proxies oder VPN-Zugriffe benötigen keine zusätzlichen Header mehr. Netzbetreibende sollten stattdessen auf
-  Netzwerkisolation, das zeitlich begrenzte Setup-WLAN sowie planmäßige Neustarts setzen.
-
-Bitte berücksichtigen: Durch den Wegfall der Tokenlogik können externe Netze die Aktionen auslösen, sofern sie auf den
-Webserver gelangen. In produktiven Umgebungen empfiehlt sich daher, den Dienst nur temporär (z. B. während des Setups)
-freizuschalten oder das Setup-WLAN strikt zu segmentieren.

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,9 @@ Diese Datei enthält eine Übersicht offener und bereits umgesetzter Aufgaben f�
 - [x] RS485‑Trigger mit tagesabhängigen Verzögerungsmatrizen
 - [x] Automatische Buchstabenausgabe in festen Intervallen
 - [x] Mehrspurige Tageskonfiguration (Buchstaben & Farben pro Triggerleitung)
-- [x] Weboberfläche für WLAN‑Daten, Anzeigeparameter und RTC‑Zeit
-- [x] Web‑UI absichern (Authentifizierung, Schutzmechanismen) – historische Token-Implementierung, bleibt deaktiviert (siehe README)
-- [x] WiFi‑Symbolanzeige und automatisches Abschalten des Webservers bei Verbindungsverlust
+- [x] Weboberfläche für Netzwerkparameter, Anzeigeeinstellungen und RTC-Zeit
+- [x] Web-UI absichern (Authentifizierung, Schutzmechanismen) – dokumentierte Altmechanik bleibt deaktiviert
+- [x] Funksignal-Symbolanzeige und automatisches Abschalten des Webservers bei Verbindungsverlust
 - [x] EEPROM‑Speicherung aller Einstellungen inklusive Farben je Wochentag
 - [x] CI aufsetzen, die den Arduino‑Code baut
 - [x] Zeitsynchronisation per NTP

--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -60,23 +60,6 @@ existieren, weist das Skript darauf hin. Sobald der Dienst installiert ist, kann
 problemlos starten und die Lease-Datei exklusiv schreiben, während andere Benutzer:innen nur noch lesenden Zugriff über die
 Gruppenmitgliedschaft erhalten.
 
-## WLAN / Access Point
-
-Die SSID und das WPA2-Passwort für den öffentlichen Access Point werden zentral in `/etc/usbstick/public_ap.env`
-verwaltet. Dieses Environment-File wird von allen relevanten Komponenten (`bootlocal.sh`, `/root/install_public_ap.sh`,
-`/root/install_public_ap_setuphelper.sh`) eingelesen und in die Templates für `hostapd` und `dnsmasq` übertragen.
-Änderungen an den Zugangsdaten müssen daher nur an einer Stelle vorgenommen werden.
-
-**Vorgehen für bestehende Installationen:**
-
-1. `sudo vi /etc/usbstick/public_ap.env` (oder Editor der Wahl) und Werte für `SSID` bzw. `WPA_PASSPHRASE` anpassen.
-2. `sudo /root/install_public_ap.sh` ausführen oder – falls das System via SetupHelper verwaltet wird – `sudo /root/install_public_ap_setuphelper.sh` starten.
-3. Das Skript regeneriert `hostapd.conf` und `dnsmasq.conf`, setzt notwendige Rechte und startet die Services neu. Ein Reboot ist nicht erforderlich.
-
-Das ausgelieferte `hostapd.conf` im Verzeichnis `files/etc/hostapd/` dient als Template und bleibt so jederzeit mit den Laufzeitdateien synchron.
-Bei System-Updates sollte immer zuerst das Environment-File geprüft und gegebenenfalls angepasst werden; die Installer-Skripte übernehmen
-anschließend den restlichen Abgleich.
-
 ## Legacy-Skripte
 
 Die vorherigen monolithischen Installationsskripte wurden in [`archive/legacy-root-scripts/`](archive/legacy-root-scripts)


### PR DESCRIPTION
## Summary
- Aktualisiere die README, indem veraltete Token- und WLAN-Abschnitte entfernt und neutrale Formulierungen genutzt werden
- Säubere TODO und CHANGELOG von Verweisen auf Token- bzw. WLAN-Themen und passe Begriffe an
y- Streiche den WLAN-spezifischen Abschnitt aus der USBStick-Setup-Dokumentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe1741a82883308fc22b352ef4cd9d