### PR TITLE
Rename shutdown loopback test

### DIFF
--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -1221,7 +1221,7 @@ def test_shutdown_allows_remote_clients(webserver_app, monkeypatch):
     assert calls == ["poweroff"]
 
 
-def test_shutdown_allows_loopback_without_token(webserver_app, monkeypatch):
+def test_shutdown_allows_loopback_without_auth(webserver_app, monkeypatch):
     module, client = webserver_app
     monkeypatch.setattr(module.os, "system", lambda cmd: None)
 


### PR DESCRIPTION
## Summary
- rename the shutdown loopback test to remove the token wording

## Testing
- pytest tests/test_webserver.py

------
https://chatgpt.com/codex/tasks/task_e_68fe264a1db483309759921ae58b1cf7