### PR TITLE
Entferne Authentifizierungsreferenzen aus TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,13 +14,11 @@ Diese Datei enthält eine Übersicht offener und bereits umgesetzter Aufgaben f�
 - [x] Automatische Buchstabenausgabe in festen Intervallen
 - [x] Mehrspurige Tageskonfiguration (Buchstaben & Farben pro Triggerleitung)
 - [x] Weboberfläche für Netzwerkparameter, Anzeigeeinstellungen und RTC-Zeit
-- [x] Web-UI absichern (Authentifizierung, Schutzmechanismen) – dokumentierte Altmechanik bleibt deaktiviert
 - [x] Funksignal-Symbolanzeige und automatisches Abschalten des Webservers bei Verbindungsverlust
 - [x] EEPROM‑Speicherung aller Einstellungen inklusive Farben je Wochentag
 - [x] CI aufsetzen, die den Arduino‑Code baut
 - [x] Zeitsynchronisation per NTP
 
 ## Ergänzende Ideen
-- [ ] Authentifizierungsoptionen (Passwortschutz oder OAuth) – verworfen, keine zusätzliche Authentifizierung mehr vorgesehen
 - [ ] Upload eigener Bitmaps zum Erweitern der Buchstaben/Symbole
 - [ ] Weitere Triggerquellen (z.B. HTTP‑API oder MQTT)


### PR DESCRIPTION
## Summary
- entferne alle authentifizierungsbezogenen Einträge aus der Roadmap
- stelle konsistente Listenstruktur nach den Löschungen sicher

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe2643de848330ab936d7a4925990c