### PR TITLE
Aktualisiere Meldung für Vorversion und passe Web-Parameter-Konstanz an

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -367,7 +367,7 @@ void loadConfig() {
         EEPROM.get(EEPROM_OFFSET_DAILY_LETTER_COLORS, dailyLetterColors);
         sanitizeColorMatrix(dailyLetterColors);
     } else if (storedVersion == EEPROM_CONFIG_VERSION_WITH_AUTH) {
-        Serial.println(F("ℹ️ Konfiguration der Vorversion (mit Token-Schutz) erkannt – übernehme Werte ohne Authentifizierung."));
+        Serial.println(F("ℹ️ Konfiguration der Vorversion erkannt – übernehme Werte unverändert."));
         loadConfigFromVersion4Layout();
         migratedLegacyLayout = true;
     } else {

--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -703,9 +703,9 @@ void setupWebServer() {
             return;
         }
 
-        AsyncWebParameter *brightnessParam = request->getParam("brightness", true);
-        AsyncWebParameter *letterTimeParam = request->getParam("letter_time", true);
-        AsyncWebParameter *autoIntervalParam = request->getParam("auto_interval", true);
+        const AsyncWebParameter *brightnessParam = request->getParam("brightness", true);
+        const AsyncWebParameter *letterTimeParam = request->getParam("letter_time", true);
+        const AsyncWebParameter *autoIntervalParam = request->getParam("auto_interval", true);
 
         long brightnessCandidate = 0;
         if (!parseSignedLongInRange(brightnessParam->value(), 1L, 255L, brightnessCandidate)) {


### PR DESCRIPTION
## Zusammenfassung
- Formuliere die Ausgabe beim Laden der Vorversion neutraler und behalte Formatierung bei.
- Passe die Verwendung von AsyncWebParameter auf konstante Zeiger an, um mit der aktuellen ESPAsyncWebServer-Signatur zu kompilieren.

## Tests
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68fe265402a88330bb08bd3bf8df1ac2