### PR TITLE
Entferne Authentifizierungs- und WLAN-Hinweise aus dem CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Änderungsprotokoll
 
 ## [Unveröffentlicht]
-- Bereinigt `loadConfig()` nun auch die drahtlosen Zugangsdaten und den Hostnamen, wenn EEPROM-Zellen mit `0xFF`, Leerstrings oder nicht druckbaren Zeichen gefüllt sind, und speichert die Defaults sofort zurück.
-- Frühere Authentifizierungsmechanismen im Firmware-Webserver sowie im SetupHelper entfernt; sämtliche Shutdown- und Verwaltungs-
-  Endpunkte stehen ohne zusätzliche Header oder Browser-Dialoge zur Verfügung. Frontend und Tests
-  spiegeln das neue Verhalten wider.
-- Automatisierter Flask-Test prüft den direkten Zugriff und verifiziert weiterhin die Robustheit der Konfigurations-
-  Speicherung.
 - `setup.sh` setzt die Lease-Datei `var/lib/misc/dnsmasq.leases` nun mit Eigentümer `root:dnsmasq` auf `0640`, legt sie bei
   Bedarf idempotent an und dokumentiert die Abhängigkeit vom Dienstkonto, damit `dnsmasq` trotz restriktiver Rechte weiterhin
   startet.
@@ -18,4 +12,3 @@
   gegen bösartige IP-Strings abgesichert.
 - Neues 32×32-Bitmap „Sun+Rad“ (`'*'`) kombiniert Sonne und Riesenrad, wird in `loadLetterData()` registriert und besitzt einen
   Host-Test, der Mapping und aktive Pixel verifiziert.
-- **2024-05-21 – Dokumentationsupdate:** README und TODO beschreiben nun das Offline-Sicherheitskonzept ohne zusätzliche Authentifizierung; dieses Zielbild soll unverändert bestehen bleiben.


### PR DESCRIPTION
## Zusammenfassung
- entferne im Abschnitt "Unveröffentlicht" sämtliche Stichpunkte mit Verweisen auf Authentifizierung sowie Offline- oder WLAN-Sicherheit
- lasse die verbleibenden Einträge unverändert, sodass keine Token- oder WLAN-Themen mehr erwähnt werden

## Testhinweise
- keine Tests erforderlich

------
https://chatgpt.com/codex/tasks/task_e_68fe263cd068833093e459e80dbc4734