### PR TITLE
Berücksichtige optionalen Automodus-Parameter

### DIFF
--- a/src/web_manager.cpp
+++ b/src/web_manager.cpp
@@ -725,8 +725,10 @@ void setupWebServer() {
             return;
         }
 
-        bool autoModeCandidate = false;
+        bool autoModeCandidate = autoDisplayMode;
+        bool autoModeProvided = false;
         if (request->hasParam("auto_mode", true)) {
+            autoModeProvided = true;
             String autoModeValue = request->getParam("auto_mode", true)->value();
             autoModeValue.trim();
             autoModeValue.toLowerCase();
@@ -748,10 +750,21 @@ void setupWebServer() {
         }
         letter_display_time = letterTimeCandidate;
         letter_auto_display_interval = autoIntervalCandidate;
-        autoDisplayMode = autoModeCandidate;
+        if (autoModeProvided) {
+            autoDisplayMode = autoModeCandidate;
+        }
 
         saveConfig();
-        request->send(200, "text/plain", "✅ Anzeigeeinstellungen gespeichert!");
+
+        String responseMessage = F("✅ Anzeigeeinstellungen gespeichert!");
+        if (autoModeProvided) {
+            responseMessage += F(" Automodus: ");
+            responseMessage += (autoDisplayMode ? F("aktiviert.") : F("deaktiviert."));
+        } else {
+            responseMessage += F(" Automodus unverändert.");
+        }
+
+        request->send(200, "text/plain", responseMessage);
     });
 
     server.on("/updateTriggerDelays", HTTP_POST, [](AsyncWebServerRequest *request) {

--- a/tests/test_update_display_settings_handler.py
+++ b/tests/test_update_display_settings_handler.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _extract_update_display_settings_handler() -> str:
+    code = Path("src/web_manager.cpp").read_text(encoding="utf-8")
+    pattern = re.compile(
+        r'server\.on\("/updateDisplaySettings".*?request->send\(200,\s*"text/plain",\s*responseMessage\);\s*\}\);',
+        re.S,
+    )
+    match = pattern.search(code)
+    assert match, "Handler-Definition für /updateDisplaySettings nicht gefunden"
+    return match.group(0)
+
+
+def test_update_display_settings_preserves_auto_mode_without_param() -> None:
+    handler = _extract_update_display_settings_handler()
+
+    assert "bool autoModeCandidate = autoDisplayMode;" in handler
+    assert "bool autoModeProvided = false;" in handler
+    assert "if (autoModeProvided) {\n            autoDisplayMode = autoModeCandidate;\n        }" in handler
+    assert "Automodus unverändert." in handler


### PR DESCRIPTION
## Summary
- initialisiere den Automodus-Kandidaten mit dem aktuellen Zustand und markiere, ob ein auto_mode-Parameter übermittelt wurde
- übernehme neue Automodus-Werte nur bei expliziter Vorgabe und ergänze die Antwortmeldung um den Statushinweis
- ergänze einen Host-Test, der sicherstellt, dass der Handler den Automodus ohne Parameter unverändert belässt

## Testing
- pio run *(fehlgeschlagen: command not found)*
- pytest tests/test_update_display_settings_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68fe4236b7048330b2c26fcec959a862