### PR TITLE
Allow empty box order updates

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -853,9 +853,9 @@ def remove_box():
 @app.route("/update_box_order", methods=["POST"])
 def update_box_order():
 
-    data = request.json
+    data = request.get_json(silent=True) or {}
     boxOrder = data.get("boxOrder")
-    if boxOrder and isinstance(boxOrder, list):
+    if isinstance(boxOrder, list):
         config = load_config()
         sanitized_order = []
         seen = set()

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -855,6 +855,27 @@ def test_update_box_order_allows_remote_clients(webserver_app):
     config = module.load_config()
     assert config["boxOrder"] == ["BoxB", "BoxA"]
 
+
+def test_update_box_order_accepts_empty_list(webserver_app):
+    module, client = webserver_app
+    module.save_config(
+        {
+            "boxen": {
+                "BoxA": _empty_box(module, ip="10.0.0.1"),
+                "BoxB": _empty_box(module, ip="10.0.0.2"),
+            },
+            "boxOrder": ["BoxA", "BoxB"],
+        }
+    )
+
+    response = client.post("/update_box_order", json={"boxOrder": []})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "success"}
+    config = module.load_config()
+    assert config["boxOrder"] == []
+
+
 def test_transfer_box_sends_all_triggers_json(webserver_app, monkeypatch):
     module, client = webserver_app
     letters = {day: [f"{day}{idx}" for idx in range(module.TRIGGER_SLOTS)] for day in module.DAYS}


### PR DESCRIPTION
## Summary
- allow the /update_box_order endpoint to accept empty lists and always persist the sanitized order
- add a regression test ensuring empty box order payloads clear the saved order

## Testing
- pytest tests/test_webserver.py

------
https://chatgpt.com/codex/tasks/task_e_68fe522733608330b8dc9420a0083dcd