### PR TITLE
Ensure kiosk startx launches kiosk script automatically

### DIFF
--- a/USBStick-Setup/files/etc/systemd/system/kiosk-startx.service
+++ b/USBStick-Setup/files/etc/systemd/system/kiosk-startx.service
@@ -6,7 +6,7 @@ Requires=getty@tty1.service
 [Service]
 Type=oneshot
 User=kioskuser
-ExecStart=/usr/bin/startx
+ExecStart=/usr/bin/startx /home/kioskuser/start_firefox.sh
 RemainAfterExit=yes
 StandardOutput=tty
 TTYPath=/dev/tty1

--- a/USBStick-Setup/files/home/kioskuser/.xinitrc
+++ b/USBStick-Setup/files/home/kioskuser/.xinitrc
@@ -1,0 +1,1 @@
+exec /home/kioskuser/start_firefox.sh

--- a/USBStick-Setup/setup.sh
+++ b/USBStick-Setup/setup.sh
@@ -142,6 +142,7 @@ set_permissions() {
     "usr/local/bin/bootlocal.sh"
     "usr/local/bin/webserver.py"
     "home/kioskuser/start_firefox.sh"
+    "home/kioskuser/.xinitrc"
     "etc/hostapd/ifupdown.sh"
     "root/install_public_ap.sh"
     "root/install_public_ap_setuphelper.sh"
@@ -207,6 +208,13 @@ enable_systemd_units() {
       warn "Service file $unit missing; cannot enable"
     fi
   done
+
+  local kiosk_unit="kiosk-startx.service"
+  if [[ -f "$TARGET_ROOT/etc/systemd/system/$kiosk_unit" ]]; then
+    run_cmd systemctl restart "$kiosk_unit"
+  else
+    warn "Service file $kiosk_unit missing; cannot restart"
+  fi
 }
 
 run_post_install_hooks() {


### PR DESCRIPTION
## Summary
- launch the kiosk Firefox script directly from startx and add an .xinitrc fallback
- install the new X init file with executable permissions during setup
- reload and restart the kiosk-startx systemd unit after deployment

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fe5de4b7748330a4d1b7bd6281ba9d