### PR TITLE
Follow-up: Ensure kiosk restart is non-blocking

### DIFF
--- a/USBStick-Setup/setup.sh
+++ b/USBStick-Setup/setup.sh
@@ -211,7 +211,7 @@ enable_systemd_units() {
 
   local kiosk_unit="kiosk-startx.service"
   if [[ -f "$TARGET_ROOT/etc/systemd/system/$kiosk_unit" ]]; then
-    run_cmd systemctl restart "$kiosk_unit"
+    run_cmd systemctl restart --no-block "$kiosk_unit"
   else
     warn "Service file $kiosk_unit missing; cannot restart"
   fi


### PR DESCRIPTION
## Summary
- restart the kiosk-startx service with --no-block so the installer does not hang

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fe611654948330abb15dc717a62fa3