### PR TITLE
Sichert StartX-Kiosk-Setup mit .xinitrc und Dokumentation

### DIFF
--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -22,6 +22,23 @@ sudo ./setup.sh --dry-run     # Nur anzeigen, was passieren würde
 sudo ./setup.sh --target /mnt/venus-os   # Installation in ein gemountetes Root-Dateisystem
 ```
 
+## Nach der Installation
+
+Der Installer ruft auf Live-Systemen automatisch `systemctl daemon-reload` auf und startet die bereitgestellten Units neu. Bei
+Offline-Installationen (z. B. `--target /mnt/...`) oder wenn `--skip-systemd` verwendet wurde, sollten diese Schritte nach dem
+Kopieren manuell erfolgen:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable kiosk-startx.service
+sudo systemctl restart kiosk-startx.service
+sudo systemctl status kiosk-startx.service
+```
+
+Die Datei [`files/home/kioskuser/.xinitrc`](files/home/kioskuser/.xinitrc) sorgt dafür, dass `startx` direkt das Skript
+[`start_firefox.sh`](files/home/kioskuser/start_firefox.sh) ausführt. So wird der Firefox-Kiosk nach einem Neustart zuverlässig
+im Vollbild gestartet.
+
 ### Optionen
 
 | Option | Beschreibung |

--- a/USBStick-Setup/files/home/kioskuser/start_firefox.sh
+++ b/USBStick-Setup/files/home/kioskuser/start_firefox.sh
@@ -6,8 +6,8 @@ xset s noblank
 
 # Ermittle die aktuelle Auflösung des Bildschirms
 RESOLUTION=$(xrandr | grep '*' | head -n1 | awk '{print $1}')
-WIDTH=$(echo $RESOLUTION | cut -d'x' -f1)
-HEIGHT=$(echo $RESOLUTION | cut -d'x' -f2)
+WIDTH=$(echo "$RESOLUTION" | cut -d'x' -f1)
+HEIGHT=$(echo "$RESOLUTION" | cut -d'x' -f2)
 
 # Falls die Auflösung nicht ermittelt werden kann, setze eine Standardauflösung
 if [ -z "$WIDTH" ] || [ -z "$HEIGHT" ]; then
@@ -16,4 +16,4 @@ if [ -z "$WIDTH" ] || [ -z "$HEIGHT" ]; then
 fi
 
 # Starte Firefox mit der ermittelten Auflösung
-/usr/bin/firefox-esr --kiosk --width $WIDTH --height $HEIGHT http://localhost:8080
+/usr/bin/firefox-esr --kiosk --width "$WIDTH" --height "$HEIGHT" http://localhost:8080

--- a/USBStick-Setup/setup.sh
+++ b/USBStick-Setup/setup.sh
@@ -142,7 +142,6 @@ set_permissions() {
     "usr/local/bin/bootlocal.sh"
     "usr/local/bin/webserver.py"
     "home/kioskuser/start_firefox.sh"
-    "home/kioskuser/.xinitrc"
     "etc/hostapd/ifupdown.sh"
     "root/install_public_ap.sh"
     "root/install_public_ap_setuphelper.sh"
@@ -153,6 +152,18 @@ set_permissions() {
       run_cmd chmod 0755 "$target"
     else
       warn "Missing executable $rel; skipping chmod"
+    fi
+  done
+
+  local -a config_paths=(
+    "home/kioskuser/.xinitrc"
+  )
+  for rel in "${config_paths[@]}"; do
+    local target="$TARGET_ROOT/$rel"
+    if [[ -e "$target" ]]; then
+      run_cmd chmod 0644 "$target"
+    else
+      warn "Konfigurationsdatei $rel fehlt; überspringe chmod"
     fi
   done
 


### PR DESCRIPTION
## Summary
- dokumentiert die notwendigen systemctl-Schritte nach dem USB-Installer-Lauf und erläutert den X-Startpfad
- härtet das Firefox-Startskript für Auflösungen mit Leerzeichen und stellt den abschließenden Zeilenumbruch sicher
- versieht setup.sh mit einer separaten Rechtebehandlung für .xinitrc, damit das Skript mit 0644 verteilt wird

## Testing
- nicht ausgeführt (nur Skript- und Dokumentationsanpassungen)


------
https://chatgpt.com/codex/tasks/task_e_68fe61ceec30833085c51af71f7a1685