### PR TITLE
Ensure kiosk .xinitrc retains executable permission

### DIFF
--- a/USBStick-Setup/setup.sh
+++ b/USBStick-Setup/setup.sh
@@ -145,6 +145,7 @@ set_permissions() {
     "etc/hostapd/ifupdown.sh"
     "root/install_public_ap.sh"
     "root/install_public_ap_setuphelper.sh"
+    "home/kioskuser/.xinitrc"
   )
   for rel in "${exec_paths[@]}"; do
     local target="$TARGET_ROOT/$rel"
@@ -155,9 +156,7 @@ set_permissions() {
     fi
   done
 
-  local -a config_paths=(
-    "home/kioskuser/.xinitrc"
-  )
+  local -a config_paths=()
   for rel in "${config_paths[@]}"; do
     local target="$TARGET_ROOT/$rel"
     if [[ -e "$target" ]]; then


### PR DESCRIPTION
## Summary
- keep the kiosk user's .xinitrc in the executable permissions list so startx can invoke it
- remove the now-empty configuration chmod list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe67b7e7448330806d8fbac7712cfe