### PR TITLE
Add default hotspot env template and improve fallback handling

### DIFF
--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -68,6 +68,27 @@ Die Provisionierung läuft sowohl bei einer Installation ins aktive Root-Dateisy
 gemounteten Ziel (sofern `chroot` verfügbar ist). Dadurch müssen Operator:innen die Abhängigkeiten nicht mehr manuell
 nachinstallieren – der Webserver ist nach Abschluss von `setup.sh` sofort startklar.
 
+## Hotspot-Zugangsdaten anpassen
+
+Der USB-Stick liefert mit [`files/etc/usbstick/public_ap.env.example`](files/etc/usbstick/public_ap.env.example) eine Vorlage
+für die WLAN-Zugangsdaten des Boot-Hotspots. Während der Installation kopiert `setup.sh` die Vorlage nach
+`/etc/usbstick/public_ap.env`, sofern dort noch keine individuelle Datei existiert oder lediglich die unveränderte Vorlage
+vorliegt. Die Datei wird mit restriktiven Rechten (`0640`) abgelegt.
+
+Passen Sie unmittelbar nach der Installation SSID und WPA-Passphrase an, damit der Hotspot nicht mit den Standardwerten
+(`RiddleMatrix-Hotspot` / `BittePasswortAnpassen123!`) aktiv bleibt:
+
+```bash
+sudo editor /etc/usbstick/public_ap.env
+# Beispielinhalt
+SSID="MeinIndividuellesNetz"
+WPA_PASSPHRASE="SehrSicheresKennwort123"
+```
+
+`bootlocal.sh` und `root/install_public_ap.sh` starten den Hotspot weiterhin, selbst wenn die Datei fehlt oder leer ist: Sie
+protokollieren den Grund und greifen auf dieselben Standardwerte zurück. Sobald gültige Werte eingetragen wurden, greifen die
+Skripte automatisch auf die konfigurierte SSID/Passphrase zurück und geben im Fehlerfall eine gut verständliche Meldung aus.
+
 ## Gesicherte Lease-Datei für dnsmasq
 
 `setup.sh` setzt beim Abschluss der Installation die Datei `var/lib/misc/dnsmasq.leases` auf den Eigentümer `root:dnsmasq`

--- a/USBStick-Setup/files/etc/usbstick/public_ap.env.example
+++ b/USBStick-Setup/files/etc/usbstick/public_ap.env.example
@@ -1,0 +1,8 @@
+# Hotspot-Konfiguration für den USB-Stick-Installer des Märchen-Managers.
+#
+# Bitte ersetzen Sie die Platzhalterwerte durch eine individuelle SSID und
+# eine WPA2-Passphrase (8–63 Zeichen). Die Werte werden von den Skripten
+# bootlocal.sh und install_public_ap.sh eingelesen, um hostapd und dnsmasq zu
+# konfigurieren.
+SSID="RiddleMatrix-Hotspot"
+WPA_PASSPHRASE="BittePasswortAnpassen123!"

--- a/USBStick-Setup/files/root/install_public_ap.sh
+++ b/USBStick-Setup/files/root/install_public_ap.sh
@@ -10,7 +10,29 @@ fi
 # shellcheck disable=SC1090
 source "$PUBLIC_AP_HELPER"
 
-public_ap_load_env
+FALLBACK_CREDENTIALS=0
+if ! public_ap_load_env; then
+    case "$PUBLIC_AP_ENV_STATUS" in
+        missing_file|empty_file)
+            echo "⚠️ $PUBLIC_AP_ENV_ERROR Hotspot wird mit Standardwerten gestartet." >&2
+            public_ap_apply_defaults
+            FALLBACK_CREDENTIALS=1
+            ;;
+        missing_ssid|missing_passphrase)
+            echo "⚠️ $PUBLIC_AP_ENV_ERROR Verwende Standardwerte aus dem Installer." >&2
+            public_ap_apply_defaults
+            FALLBACK_CREDENTIALS=1
+            ;;
+        *)
+            echo "⚠️ $PUBLIC_AP_ENV_ERROR Hotspot-Installation wird übersprungen." >&2
+            exit 0
+            ;;
+    esac
+fi
+
+if (( FALLBACK_CREDENTIALS )); then
+    echo "ℹ️ Standard-Hotspot \"$SSID\" aktiv. Bitte /etc/usbstick/public_ap.env anpassen."
+fi
 
 echo "🔐 Wende Zugangsdaten für Hotspot \"$SSID\" an..."
 

--- a/USBStick-Setup/files/usr/local/bin/bootlocal.sh
+++ b/USBStick-Setup/files/usr/local/bin/bootlocal.sh
@@ -13,7 +13,29 @@ fi
 # shellcheck disable=SC1090
 source "$PUBLIC_AP_HELPER"
 
-public_ap_load_env
+FALLBACK_CREDENTIALS=0
+if ! public_ap_load_env; then
+    case "$PUBLIC_AP_ENV_STATUS" in
+        missing_file|empty_file)
+            echo "⚠️ $PUBLIC_AP_ENV_ERROR Hotspot wird mit Standardwerten gestartet." >&2
+            public_ap_apply_defaults
+            FALLBACK_CREDENTIALS=1
+            ;;
+        missing_ssid|missing_passphrase)
+            echo "⚠️ $PUBLIC_AP_ENV_ERROR Verwende Standardwerte aus dem Installer." >&2
+            public_ap_apply_defaults
+            FALLBACK_CREDENTIALS=1
+            ;;
+        *)
+            echo "⚠️ $PUBLIC_AP_ENV_ERROR Hotspot-Start wird übersprungen." >&2
+            exit 0
+            ;;
+    esac
+fi
+
+if (( FALLBACK_CREDENTIALS )); then
+    echo "ℹ️ Standard-Hotspot \"$SSID\" aktiv. Bitte /etc/usbstick/public_ap.env anpassen."
+fi
 
 if [[ -d "$PERSIST_USR_LOCAL" ]]; then
     echo "♻️ Synchronisiere persistente /usr/local-Dateien..."


### PR DESCRIPTION
## Summary
- add a default `public_ap.env.example` with documented placeholder credentials for the USB stick installer
- extend the hotspot helper and boot/install scripts to surface configuration issues, apply safe defaults, or skip execution gracefully
- adjust `setup.sh` to deploy the template without clobbering customised credentials and document the workflow in the README

## Testing
- ./setup.sh --dry-run --target /tmp/riddle-test
- Simulated bootlocal.sh with missing env (stubbed ip/systemctl)
- Simulated bootlocal.sh with custom env (stubbed ip/systemctl)
- Simulated install_public_ap.sh with missing env (stubbed ip/systemctl)
- Simulated install_public_ap.sh with custom env (stubbed ip/systemctl)


------
https://chatgpt.com/codex/tasks/task_e_68fe66feaaf88330965f64e43ad32982