### PR TITLE
Address Codex review feedback: abort on partial hotspot env

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/bootlocal.sh
+++ b/USBStick-Setup/files/usr/local/bin/bootlocal.sh
@@ -22,9 +22,8 @@ if ! public_ap_load_env; then
             FALLBACK_CREDENTIALS=1
             ;;
         missing_ssid|missing_passphrase)
-            echo "⚠️ $PUBLIC_AP_ENV_ERROR Verwende Standardwerte aus dem Installer." >&2
-            public_ap_apply_defaults
-            FALLBACK_CREDENTIALS=1
+            echo "❌ $PUBLIC_AP_ENV_ERROR Hotspot-Start wird abgebrochen." >&2
+            exit 1
             ;;
         *)
             echo "⚠️ $PUBLIC_AP_ENV_ERROR Hotspot-Start wird übersprungen." >&2


### PR DESCRIPTION
## Summary
- abort the hotspot startup when the environment file is missing SSID or passphrase values
- ensure the boot script no longer falls back to default credentials for partially configured environments

## Testing
- not run (change is a logic adjustment only)


------
https://chatgpt.com/codex/tasks/task_e_68fe6c21ffb08330848e114df9260003