### PR TITLE
Improve provisioning hook chroot handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ pytest tests/test_webserver.py
 ```
 
 Die Tests lassen sich beliebig kombinieren, zum Beispiel mit `pytest` ohne
-Dateiangabe für eine vollständige Suite.
+Dateiangabe für eine vollständige Suite. Für den USB-Stick-Installer steht
+zusätzlich ein Dry-Run-Test zur Verfügung, der beide Pfade (`TARGET_ROOT=/`
+und ein gemountetes Zielsystem) abdeckt und sicherstellt, dass die Provisionierung
+ihre Arbeitsschritte sauber protokolliert, ohne Änderungen vorzunehmen:
+
+```bash
+pytest tests/test_provision_hook.py
+```
 
 ## Weitere Schritte
 
@@ -148,6 +155,8 @@ sudo ./setup.sh
 ```
 
 Der Installer kopiert standardmäßig den Inhalt von `USBStick-Setup/files/` auf das laufende System (`/`). Mit `--target` kann ein anderes Root-Verzeichnis (z. B. ein gemountetes Venus-OS-Image) angegeben werden, `--dry-run` zeigt geplante Schritte ohne Änderungen an und `--skip-systemd`/`--skip-hooks` deaktivieren optionale Aktionen. Weitere Details finden sich in der README im Unterordner [`USBStick-Setup`](USBStick-Setup).
+
+> **Hinweis:** Der Provisionierungs-Hook `hooks.d/10-provision-webserver.sh` prüft automatisch, ob er auf dem Live-System arbeitet oder ein Ziel unterhalb von `--target` versorgt. Für Offline-Installationen wird das virtuelle Python-Umfeld via `chroot` mit dem Python des Zielsystems erstellt, sodass erzeugte Wheels und Binaries zur Zielarchitektur passen. Ist `PROVISION_DRY_RUN=1` gesetzt (zum Beispiel in Tests), werden alle Schritte nur protokolliert.
 
 Legacy-Skripte wurden in [`USBStick-Setup/archive/legacy-root-scripts/`](USBStick-Setup/archive/legacy-root-scripts) abgelegt und stehen weiterhin als Referenz zur Verfügung.
 

--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -61,8 +61,12 @@ automatisiert um alle Laufzeitabhängigkeiten des Märchen-Managers:
 
 - prüft mittels `dpkg-query`, ob benötigte Debian-Pakete wie `dnsmasq`, `hostapd`, `rfkill`, `x11-xserver-utils`, `python3`
   (inkl. `python3-venv`) und optionale Firmware-Pakete installiert sind und stößt bei Bedarf ein `apt-get install` an
-- erzeugt das virtuelle Python-Umfeld unter `/usr/local/venv/maerchen` mit `python3 -m venv`, falls es noch nicht existiert
-- installiert fehlende Python-Abhängigkeiten (`flask`, `requests`, `beautifulsoup4`) idempotent via `pip`
+- erzeugt das virtuelle Python-Umfeld unter `/usr/local/venv/maerchen` mit `python3 -m venv`, falls es noch nicht existiert –
+  bei Offline-Zielen automatisch via `chroot`, sodass der Python des Zielsystems verwendet wird
+- installiert fehlende Python-Abhängigkeiten (`flask`, `requests`, `beautifulsoup4`) idempotent via `pip`; offline erfolgt die
+  Installation ebenfalls via `chroot`, damit Wheels und Binärmodule zur Zielarchitektur passen
+- unterstützt einen Dry-Run-Modus über die Umgebungsvariable `PROVISION_DRY_RUN=1`, der sämtliche Schritte lediglich protokolliert
+  und dadurch Tests ohne Root-Eingriffe ermöglicht
 
 Die Provisionierung läuft sowohl bei einer Installation ins aktive Root-Dateisystem (`TARGET_ROOT=/`) als auch bei einem
 gemounteten Ziel (sofern `chroot` verfügbar ist). Dadurch müssen Operator:innen die Abhängigkeiten nicht mehr manuell

--- a/tests/test_provision_hook.py
+++ b/tests/test_provision_hook.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "USBStick-Setup" / "hooks.d" / "10-provision-webserver.sh"
+
+
+def run_hook(target_root: Path | str, *, dry_run: bool = True) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["TARGET_ROOT"] = str(target_root)
+    if dry_run:
+        env["PROVISION_DRY_RUN"] = "1"
+    return subprocess.run(
+        ["bash", str(HOOK_PATH), str(target_root)],
+        cwd=HOOK_PATH.parent,
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def test_dry_run_on_host_root():
+    result = run_hook("/")
+    assert result.returncode == 0, result.stderr
+    assert "Dry-run aktiviert" in result.stdout
+    assert "virtuelle Umgebung auf dem Host" in result.stdout
+    assert "Python-Abhängigkeiten im virtuellen Host-Environment" in result.stdout
+    assert "Provisioning hook completed" in result.stdout
+
+
+def test_dry_run_on_offline_target(tmp_path):
+    target_root = tmp_path / "offline-root"
+    (target_root / "usr/bin").mkdir(parents=True)
+    python_stub = target_root / "usr/bin/python3"
+    python_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    python_stub.chmod(0o755)
+
+    result = run_hook(target_root)
+    assert result.returncode == 0, result.stderr
+    assert "Dry-run aktiviert" in result.stdout
+    assert "virtuelle Umgebung via chroot" in result.stdout
+    assert "Python-Abhängigkeiten im Zielsystem via chroot" in result.stdout
+    assert "Provisioning hook completed" in result.stdout


### PR DESCRIPTION
## Summary
- extend the provisioning hook to use chrooted Python when TARGET_ROOT is not the live system and add a dry-run mode for testing
- document the new provisioning workflow and how to exercise the dry-run checks
- cover both host and offline targets with a pytest dry-run test for the provisioning hook

## Testing
- pytest tests/test_provision_hook.py

------
https://chatgpt.com/codex/tasks/task_e_68fe6c02187883309325e50d48a85686