### PR TITLE
Härtung des Shutdown-Endpunkts im USBStick-Webserver

### DIFF
--- a/USBStick-Setup/files/etc/usbstick/public_ap.env.example
+++ b/USBStick-Setup/files/etc/usbstick/public_ap.env.example
@@ -3,6 +3,8 @@
 # Bitte ersetzen Sie die Platzhalterwerte durch eine individuelle SSID und
 # eine WPA2-Passphrase (8–63 Zeichen). Die Werte werden von den Skripten
 # bootlocal.sh und install_public_ap.sh eingelesen, um hostapd und dnsmasq zu
-# konfigurieren.
+# konfigurieren. Zusätzlich schützt der SHUTDOWN_TOKEN den Poweroff-Endpunkt
+# des lokalen Webservers; er wird als Header "X-Setup-Token" erwartet.
 SSID="RiddleMatrix-Hotspot"
 WPA_PASSPHRASE="BittePasswortAnpassen123!"
+SHUTDOWN_TOKEN="BitteTokenAnpassen123!"


### PR DESCRIPTION
## Summary
- sichern des /shutdown-Endpunkts über Token-Header aus /etc/usbstick/public_ap.env und lokale Loopback-Ausnahmen
- Ergänzung eines konfigurierbaren Abschaltkommandos sowie einer Token-Auswertung aus der Hotspot-Umgebungsdatei
- Dokumentation des benötigten SHUTDOWN_TOKEN und Aktualisierung der Beispiel-Umgebungsdatei mit passendem Kommentar

## Testing
- curl -i -X POST http://$HOST_IP:8080/shutdown
- curl -i -X POST -H 'X-Setup-Token: TestToken123' http://$HOST_IP:8080/shutdown

------
https://chatgpt.com/codex/tasks/task_e_68fe72150b748330af640eee7f01d249