### PR TITLE
Schütze bestehende Hotspot-Configs bei Tar-Fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Legacy-Skripte wurden in [`USBStick-Setup/archive/legacy-root-scripts/`](USBStic
 ### Hotspot-Zugangsdaten für den USB-Stick-Installer
 
 - Die Vorlage [`USBStick-Setup/files/etc/usbstick/public_ap.env.example`](USBStick-Setup/files/etc/usbstick/public_ap.env.example) enthält gültige Platzhalterwerte (`RiddleMatrix-Hotspot`, `BittePasswortAnpassen123!`) für SSID und WPA-Passphrase.
-- `setup.sh` kopiert die Vorlage bei der Installation einmalig nach `/etc/usbstick/public_ap.env`, sofern dort noch keine Datei existiert. Dry-Runs weisen den Schritt explizit als geplante Aktion aus.
+- `setup.sh` kopiert die Vorlage bei der Installation einmalig nach `/etc/usbstick/public_ap.env`, sofern dort noch keine Datei existiert. Dry-Runs weisen den Schritt explizit als geplante Aktion aus. Sowohl der reguläre `rsync`-Pfad als auch der `tar`-Fallback schließen die Datei beim reinen Kopieren des Payloads aus und protokollieren, dass vorhandene Hotspot-Konfigurationen unangetastet bleiben.
 - `bootlocal.sh` und `root/install_public_ap.sh` protokollieren fehlende oder unvollständige Dateien, verweisen auf die Vorlage und greifen automatisch auf dieselben Standardwerte zurück, anstatt mit einem Fehler abzubrechen.
 - Nach der Installation sollten die Werte in `/etc/usbstick/public_ap.env` direkt angepasst werden, um individuelle Hotspot-Zugangsdaten zu verwenden.
 

--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -77,7 +77,9 @@ nachinstallieren – der Webserver ist nach Abschluss von `setup.sh` sofort star
 Der USB-Stick liefert mit [`files/etc/usbstick/public_ap.env.example`](files/etc/usbstick/public_ap.env.example) eine Vorlage
 für die WLAN-Zugangsdaten des Boot-Hotspots. Während der Installation kopiert `setup.sh` die Vorlage nach
 `/etc/usbstick/public_ap.env`, sofern dort noch keine individuelle Datei existiert. Die Datei wird mit restriktiven Rechten
-(`0640`) abgelegt.
+(`0640`) abgelegt. Das reine Kopieren des Payloads schließt `/etc/usbstick/public_ap.env` konsequent aus – unabhängig davon,
+ob `setup.sh` den bevorzugten `rsync`-Pfad oder den automatischen `tar`-Fallback nutzt. Das Skript protokolliert den Ausschluss
+explizit, sodass in den Logs ersichtlich bleibt, dass vorhandene Hotspot-Konfigurationen nicht überschrieben werden.
 
 Passen Sie unmittelbar nach der Installation SSID und WPA-Passphrase an, damit der Hotspot nicht mit den Standardwerten
 (`RiddleMatrix-Hotspot` / `BittePasswortAnpassen123!`) aktiv bleibt:


### PR DESCRIPTION
## Summary
- verhindere im Tar-Fallback das Überschreiben von etc/usbstick/public_ap.env und behalte die rsync-Excludes bei
- ergänze Protokollausgaben, die den Ausschluss vorhandener Hotspot-Konfigurationen sichtbar machen
- dokumentiere das Verhalten in den beiden README-Dateien

## Testing
- `USBStick-Setup/setup.sh --dry-run --skip-systemd --skip-hooks --target /tmp/tmp.kQ34caUuAh`
- `USBStick-Setup/setup.sh --skip-systemd --skip-hooks --target /tmp/tmp.rdR9ADIncg`
- `PATH="/tmp/tmp.Hb3XK7UVw8" USBStick-Setup/setup.sh --dry-run --skip-systemd --skip-hooks --target /tmp/tmp.KU11IRUjr3`
- `PATH="/tmp/tmp.Hb3XK7UVw8" USBStick-Setup/setup.sh --skip-systemd --skip-hooks --target /tmp/tmp.7oj6suOPy2`


------
https://chatgpt.com/codex/tasks/task_e_68fe80ad38f88330b8eabad5486a5b72