### PR TITLE
Handle legacy dnsmasq.conf without conf-dir

### DIFF
--- a/USBStick-Setup/files/root/install_public_ap.sh
+++ b/USBStick-Setup/files/root/install_public_ap.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 PUBLIC_AP_DNSMASQ_DROPIN_DEFAULT="/etc/dnsmasq.d/riddlematrix-hotspot.conf"
-LEGACY_DNSMASQ_CONFIG="/etc/dnsmasq.conf"
-export PUBLIC_AP_DNSMASQ_CONFIG="${PUBLIC_AP_DNSMASQ_CONFIG:-$PUBLIC_AP_DNSMASQ_DROPIN_DEFAULT}"
+PUBLIC_AP_LEGACY_DNSMASQ_CONFIG="/etc/dnsmasq.conf"
+LEGACY_DNSMASQ_CONFIG="$PUBLIC_AP_LEGACY_DNSMASQ_CONFIG"
+export PUBLIC_AP_DNSMASQ_DROPIN_DEFAULT
+export PUBLIC_AP_LEGACY_DNSMASQ_CONFIG
 
 PUBLIC_AP_HELPER="/usr/local/libexec/public_ap.sh"
 if [[ ! -f "$PUBLIC_AP_HELPER" ]]; then
@@ -15,13 +17,23 @@ fi
 source "$PUBLIC_AP_HELPER"
 
 notify_legacy_dnsmasq() {
-    if [[ -f "$LEGACY_DNSMASQ_CONFIG" && ! -L "$LEGACY_DNSMASQ_CONFIG" ]]; then
-        if grep -q "RiddleMatrix-Hotspot" "$LEGACY_DNSMASQ_CONFIG" 2>/dev/null; then
-            echo "ℹ️ Legacy-Hotspot-Konfiguration $LEGACY_DNSMASQ_CONFIG bleibt unverändert; Drop-in $PUBLIC_AP_DNSMASQ_CONFIG wird aktualisiert."
-        else
-            echo "ℹ️ Bestehende dnsmasq-Konfiguration $LEGACY_DNSMASQ_CONFIG bleibt unangetastet; Drop-in $PUBLIC_AP_DNSMASQ_CONFIG übernimmt die Hotspot-Einstellungen."
-        fi
-    fi
+    case "${PUBLIC_AP_DNSMASQ_CONFIG_MODE:-}" in
+        legacy)
+            echo "ℹ️ Legacy-dnsmasq-Konfiguration $PUBLIC_AP_DNSMASQ_CONFIG wird weiterhin aktualisiert (conf-dir fehlt in $LEGACY_DNSMASQ_CONFIG). Bitte conf-dir=/etc/dnsmasq.d ergänzen, um auf das Drop-in $PUBLIC_AP_DNSMASQ_DROPIN_DEFAULT umzusteigen."
+            ;;
+        dropin)
+            if [[ -f "$LEGACY_DNSMASQ_CONFIG" && ! -L "$LEGACY_DNSMASQ_CONFIG" ]]; then
+                if grep -q "RiddleMatrix-Hotspot" "$LEGACY_DNSMASQ_CONFIG" 2>/dev/null; then
+                    echo "ℹ️ Legacy-Hotspot-Konfiguration $LEGACY_DNSMASQ_CONFIG bleibt unverändert; Drop-in $PUBLIC_AP_DNSMASQ_CONFIG wird aktualisiert."
+                else
+                    echo "ℹ️ Bestehende dnsmasq-Konfiguration $LEGACY_DNSMASQ_CONFIG bleibt unangetastet; Drop-in $PUBLIC_AP_DNSMASQ_CONFIG übernimmt die Hotspot-Einstellungen."
+                fi
+            fi
+            ;;
+        *)
+            :
+            ;;
+    esac
 }
 
 FALLBACK_CREDENTIALS=0


### PR DESCRIPTION
## Summary
- detect legacy dnsmasq setups without conf-dir and keep writing the legacy config
- expose drop-in defaults to the helper and refine the legacy notification messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe8588a5b88330bf807d5b70d25614