### PR TITLE
Ensure kioskuser user exists before restarting kiosk service

### DIFF
--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -35,6 +35,11 @@ sudo systemctl restart kiosk-startx.service
 sudo systemctl status kiosk-startx.service
 ```
 
+Während `setup.sh` auf dem Live-System läuft, prüft es zusätzlich, ob der Benutzer `kioskuser` existiert, und legt ihn bei
+Bedarf samt Home-Verzeichnis und `/bin/bash` als Login-Shell an. Jeder Pfad wird im Log dokumentiert – inklusive Dry-Run-
+Hinweisen sowie klarer Warnungen, falls das Anlegen scheitert. Misslingt die Benutzeranlage trotz Versuch, wird der Neustart
+von `kiosk-startx.service` übersprungen und im Log als Warnung vermerkt; alle übrigen Installationsschritte laufen jedoch weiter.
+
 Die Datei [`files/home/kioskuser/.xinitrc`](files/home/kioskuser/.xinitrc) sorgt dafür, dass `startx` direkt das Skript
 [`start_firefox.sh`](files/home/kioskuser/start_firefox.sh) ausführt. So wird der Firefox-Kiosk nach einem Neustart zuverlässig
 im Vollbild gestartet.


### PR DESCRIPTION
## Summary
- add an ensure_kioskuser helper that verifies and creates the kioskuser account with detailed logging
- invoke the helper before adjusting ownership and restarting kiosk-startx.service, skipping the restart if the user is unavailable
- document the new kioskuser handling and warning behavior in the USB stick setup README

## Testing
- bash -n USBStick-Setup/setup.sh

------
https://chatgpt.com/codex/tasks/task_e_68fe8813f50883309ad41c11f0a5c495