### PR TITLE
Adjust kiosk-startx service to run continuously

### DIFF
--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -35,6 +35,10 @@ sudo systemctl restart kiosk-startx.service
 sudo systemctl status kiosk-startx.service
 ```
 
+`kiosk-startx.service` ist jetzt als `Type=simple` ausgelegt und startet `startx` ohne Zeitlimit. Dank `Restart=on-failure`
+und `RestartSec=5` versucht systemd einen Neustart, falls Firefox oder der X-Server unerwartet enden. Damit die neue
+Konfiguration greift, ist `systemctl daemon-reload` nach jeder Änderung an der Service-Datei zwingend erforderlich.
+
 Während `setup.sh` auf dem Live-System läuft, prüft es zusätzlich, ob der Benutzer `kioskuser` existiert, und legt ihn bei
 Bedarf samt Home-Verzeichnis und `/bin/bash` als Login-Shell an. Jeder Pfad wird im Log dokumentiert – inklusive Dry-Run-
 Hinweisen sowie klarer Warnungen, falls das Anlegen scheitert. Misslingt die Benutzeranlage trotz Versuch, wird der Neustart

--- a/USBStick-Setup/files/etc/systemd/system/kiosk-startx.service
+++ b/USBStick-Setup/files/etc/systemd/system/kiosk-startx.service
@@ -4,10 +4,12 @@ After=getty@tty1.service
 Requires=getty@tty1.service
 
 [Service]
-Type=oneshot
+Type=simple
 User=kioskuser
 ExecStart=/usr/bin/startx /home/kioskuser/start_firefox.sh
-RemainAfterExit=yes
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=infinity
 StandardOutput=tty
 TTYPath=/dev/tty1
 

--- a/USBStick-Setup/setup.sh
+++ b/USBStick-Setup/setup.sh
@@ -342,6 +342,7 @@ enable_systemd_units() {
 
   local -a units=(bootlocal.service webserver.service kiosk-startx.service)
   run_cmd systemctl daemon-reload
+  log "Systemd-Konfiguration neu geladen; kiosk-startx.service läuft nun als Type=simple mit automatischem Neustart bei Fehlern."
   for unit in "${units[@]}"; do
     if [[ -f "$TARGET_ROOT/etc/systemd/system/$unit" ]]; then
       run_cmd systemctl enable "$unit"


### PR DESCRIPTION
## Summary
- switch kiosk-startx.service to Type=simple and add restart/backoff settings so startx runs without timeout
- log the updated service behavior during setup.sh and document the change in the USB stick README

## Testing
- not run (systemd is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68fe949cc5948330acb52355854059fa