### PR TITLE
Frontend: Shutdown-Token konfigurierbar machen

### DIFF
--- a/USBStick-Setup/README.md
+++ b/USBStick-Setup/README.md
@@ -140,6 +140,18 @@ protokollieren den Grund, verweisen auf die Vorlage und greifen auf dieselben St
 eingetragen wurden, nutzen die Skripte automatisch die konfigurierte SSID/Passphrase und geben im Fehlerfall eine gut
 verständliche Meldung aus.
 
+### Shutdown-Token im Frontend hinterlegen
+
+1. Das Webfrontend des Märchen-Managers stellt in der linken Seitenleiste ein Feld **„Shutdown-Token“** bereit.
+2. Tragen Sie dort das Token ein, das auch in `/etc/usbstick/public_ap.env` unter `SHUTDOWN_TOKEN` abgelegt ist, und bestätigen Sie die Eingabe (Blur oder Enter). Der Wert wird browserseitig in `localStorage` gespeichert und bleibt auch nach einem Reload erhalten.
+3. Sobald ein Token gespeichert ist, zeigt die Statuszeile unterhalb des Feldes „Token gespeichert.“ an. Ohne Token erscheint der Hinweis „Kein Token gespeichert.“
+4. Beim Auslösen des Buttons **„Herunterfahren“** sendet das Frontend automatisch den HTTP-Header `X-Setup-Token: <wert>` an `/shutdown`. Fehlt ein hinterlegtes Token, informiert ein Dialog darüber und bietet ausschließlich für lokale Tests (Zugriff direkt vom Gerät) die Option, den Shutdown ohne Header fortzusetzen.
+
+**Testempfehlung:**
+
+- **Lokal (z. B. Browser direkt auf dem Gerät):** Dialog bestätigen, um einmalig ohne Token zu testen. Der Backend-Endpunkt akzeptiert lokale Hosts auch ohne Header.
+- **Remote (anderes Gerät im Netzwerk):** Ein gültiges Token im Feld hinterlegen. Der Button verschickt den Header automatisch; ohne Token wird der Shutdown verweigert.
+
 ## Gesicherte Lease-Datei für dnsmasq
 
 `setup.sh` setzt beim Abschluss der Installation die Datei `var/lib/misc/dnsmasq.leases` auf den Eigentümer `root:dnsmasq`

--- a/USBStick-Setup/files/usr/local/etc/index.html
+++ b/USBStick-Setup/files/usr/local/etc/index.html
@@ -58,6 +58,35 @@
     }
     #shutdown { background: red; color: white; }
     #setupBtn { background: #555; color: white; width: 100%; }
+    .token-settings {
+      margin-top: 15px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .token-settings label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .token-settings input {
+      padding: 8px;
+      border-radius: 4px;
+      border: 1px solid #777;
+      font-size: 14px;
+      background: #222;
+      color: #fff;
+    }
+    .token-status {
+      font-size: 12px;
+      min-height: 16px;
+    }
+    .token-status.saved {
+      color: #9be89b;
+    }
+    .token-status.missing {
+      color: #ffb3b3;
+    }
     #content {
       flex-grow: 1; background: #f4f4f4; padding: 0; overflow-y: auto; position: relative;
     }
@@ -123,6 +152,11 @@
     <button id="setupBtn" onclick="showSetup()">Boxen verwalten</button>
     <div id="deviceList">Lade...</div>
   </div>
+  <div class="token-settings">
+    <label for="shutdownTokenInput">Shutdown-Token</label>
+    <input id="shutdownTokenInput" type="text" autocomplete="off" placeholder="Token eintragen" />
+    <div id="shutdownTokenStatus" class="token-status"></div>
+  </div>
   <button id="shutdown" onclick="shutdown()">Herunterfahren</button>
 </div>
 <div id="content"><p>Willkommen im Märchen-Manager</p></div>
@@ -142,6 +176,9 @@ const colorPattern = /^#[0-9A-Fa-f]{6}$/;
 const letterLabels = {"*": "Sun+Rad", "#": "Sun", "~": "WIFI", "&": "Rad", "?": "Riddler"};
 const letterOptions = "ABCDEFGHIJKLMNOPQRSTUVWXYZ*#~&?".split("");
 let currentWordTrigger = 0;
+const SHUTDOWN_TOKEN_KEY = "setupShutdownToken";
+let shutdownTokenInput;
+let shutdownTokenStatus;
 function escapeHtml(value) {
   return String(value ?? "")
     .replace(/&/g, "&amp;")
@@ -169,8 +206,63 @@ function escapeJsString(value) {
 }
 
 function init() {
+  initShutdownTokenHandling();
   fetchDevices();
   setInterval(fetchDevices, 1000); // Prüfe alle 1 Sekunde
+}
+
+function initShutdownTokenHandling() {
+  shutdownTokenInput = document.getElementById("shutdownTokenInput");
+  shutdownTokenStatus = document.getElementById("shutdownTokenStatus");
+  if (!shutdownTokenInput) {
+    return;
+  }
+
+  const storedValue = localStorage.getItem(SHUTDOWN_TOKEN_KEY) || "";
+  shutdownTokenInput.value = storedValue;
+  updateShutdownTokenStatus(storedValue);
+
+  shutdownTokenInput.addEventListener("change", persistShutdownToken);
+  shutdownTokenInput.addEventListener("blur", persistShutdownToken);
+  shutdownTokenInput.addEventListener("input", () => {
+    updateShutdownTokenStatus(shutdownTokenInput.value);
+  });
+}
+
+function persistShutdownToken() {
+  if (!shutdownTokenInput) {
+    return;
+  }
+
+  const trimmedValue = shutdownTokenInput.value.trim();
+  if (trimmedValue) {
+    localStorage.setItem(SHUTDOWN_TOKEN_KEY, trimmedValue);
+    shutdownTokenInput.value = trimmedValue;
+  } else {
+    localStorage.removeItem(SHUTDOWN_TOKEN_KEY);
+  }
+  updateShutdownTokenStatus(trimmedValue);
+}
+
+function getShutdownToken() {
+  const value = localStorage.getItem(SHUTDOWN_TOKEN_KEY) || "";
+  return value.trim();
+}
+
+function updateShutdownTokenStatus(currentValue) {
+  if (!shutdownTokenStatus) {
+    return;
+  }
+  const normalizedValue = typeof currentValue === "string" ? currentValue.trim() : getShutdownToken();
+  if (normalizedValue) {
+    shutdownTokenStatus.textContent = "Token gespeichert.";
+    shutdownTokenStatus.classList.remove("missing");
+    shutdownTokenStatus.classList.add("saved");
+  } else {
+    shutdownTokenStatus.textContent = "Kein Token gespeichert.";
+    shutdownTokenStatus.classList.remove("saved");
+    shutdownTokenStatus.classList.add("missing");
+  }
 }
 
 function normalizeBox(box) {
@@ -268,13 +360,32 @@ async function shutdown() {
     return;
   }
 
+  const token = getShutdownToken();
+  if (!token) {
+    updateShutdownTokenStatus("");
+    const proceedWithoutToken = window.confirm(
+      "Es ist kein Shutdown-Token hinterlegt. Für entfernte Zugriffe ist das Token zwingend erforderlich. " +
+      "Für lokale Tests (direkter Zugriff auf das Gerät) kann ohne Token fortgefahren werden. Möchten Sie trotzdem ohne Token fortfahren?"
+    );
+    if (!proceedWithoutToken) {
+      if (shutdownTokenInput) {
+        shutdownTokenInput.focus();
+      }
+      return;
+    }
+  }
+
   const shutdownButton = document.getElementById("shutdown");
   const originalLabel = shutdownButton.textContent;
   shutdownButton.disabled = true;
   shutdownButton.textContent = "Wird heruntergefahren...";
 
   try {
-    const response = await fetch("/shutdown", { method: "POST" });
+    const fetchOptions = { method: "POST" };
+    if (token) {
+      fetchOptions.headers = { "X-Setup-Token": token };
+    }
+    const response = await fetch("/shutdown", fetchOptions);
     if (!response.ok) {
       alert("Fehler beim Abschalten: " + response.statusText);
       return;


### PR DESCRIPTION
## Zusammenfassung
- ergänzt im Frontend ein lokales Eingabefeld für das Shutdown-Token inklusive Statusanzeige und Speicherung im Browser
- erweitert den Shutdown-Button um konfigurierbare Token-Header sowie eine Hinweisabfrage für lokale Tests ohne Token
- dokumentiert in der README den Ablauf zum Setzen des Tokens im Web-Frontend und die empfohlenen Tests für lokale und Remote-Zugriffe

## Tests
- Keine automatisierten Tests erforderlich (Frontend-Anpassung)


------
https://chatgpt.com/codex/tasks/task_e_68fea060e59083309087e9e80ca9e55e