### PR TITLE
Add pytest dependency for test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Nach der Installation muss der Befehl `pio` im `PATH` verfügbar sein.
 ## Tests
 
 Vor den Host-Tests müssen die Python-Abhängigkeiten installiert werden. Die Datei
-`requirements-test.txt` bündelt aktuell die Flask-Version, die für die Webserver-Tests
-benötigt wird:
+`requirements-test.txt` bündelt aktuell die für die Host-Tests benötigten Pakete –
+inklusive `pytest` für die Testausführung sowie der Webserver-Abhängigkeiten (`Flask`,
+`beautifulsoup4`, `requests`):
 
 ```bash
 pip install -r requirements-test.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 Flask>=2.3,<3.0
 beautifulsoup4>=4.12,<5
 requests>=2.31,<3
+pytest>=7.4,<9


### PR DESCRIPTION
## Summary
- add an explicit pytest version constraint to requirements-test.txt so local environments install the test runner
- document the expanded dependency list in the README so contributors know to install pytest alongside the web test stack

## Testing
- pip install -r requirements-test.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fea67082c48330a7482db41c10423e