### PR TITLE
Trim hostname values returned from web UI

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -766,7 +766,10 @@ def get_hostname_from_web(ip):
         if hostname_field is not None:
             value = hostname_field.get("value")
             if value is not None:
-                return value
+                if isinstance(value, str):
+                    value = value.strip()
+                if value:
+                    return value
     return "Unbekannt"
 
 def learn_box(ip, identifier):


### PR DESCRIPTION
## Summary
- trim hostnames extracted from the web UI and fall back to "Unbekannt" when the field is empty
- adjust hostname parsing test to expect trimmed values
- add regression test covering empty hostname values so sanitize_hostname no longer generates random fallbacks

## Testing
- pytest tests/test_webserver.py

------
https://chatgpt.com/codex/tasks/task_e_68feaab312648330b93b653a8fd1bc86