### PR TITLE
Follow-up: Sanitize unique hostname candidates

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -277,6 +277,7 @@ def _allocate_unique_hostname(base_name: str, config: dict) -> str:
         else:
             candidate = suffix_str[-MAX_HOSTNAME_LENGTH:]
 
+        candidate = sanitize_hostname(candidate)
         if candidate not in boxen:
             return candidate
 


### PR DESCRIPTION
## Summary
- sanitize generated hostname candidates in `_allocate_unique_hostname` before checking for collisions
- ensure uniqueness checks use the same normalization as when persisting hostnames

## Testing
- pytest tests/test_webserver.py

------
https://chatgpt.com/codex/tasks/task_e_68ff556967888330a7d2bb50754d08c4