### PR TITLE
Validierung für ungültige Buchstaben in update_box

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Die Tagesbuchstaben werden jetzt dreidimensional abgelegt:
 
 Trigger-Index `0` entspricht RS485-Trigger 1, Index `1` Trigger 2 usw. Die Weboberfläche unter `/` zeigt die Werte als Matrix an und erlaubt das gleichzeitige Aktualisieren über `/updateAllLetters`.
 
+> **API-Hinweis:** Die Route `/update_box` verweigert Leerzeichen oder nicht unterstützte Zeichen jetzt mit HTTP 400. Die
+> Konfiguration bleibt dabei unverändert, sodass Clients ausschließlich gültige Zeichen aus dem zugelassenen Zeichensatz senden
+> müssen.
+
 | Wochentag   | Trigger 1 (`#RRGGBB`) | Trigger 2 (`#RRGGBB`) | Trigger 3 (`#RRGGBB`) |
 |-------------|-----------------------|-----------------------|-----------------------|
 | Sonntag     | A (`#FF0000`)         | H (`#FFFFFF`)         | O (`#FFA07A`)         |


### PR DESCRIPTION
## Summary
- verhindern, dass `update_box` leere oder ungültige Buchstaben übernimmt, und bei Fehlern HTTP 400 mit aussagekräftiger Meldung zurückgeben
- Testabdeckung für abgelehnte Buchstaben erweitern und bestehende Erwartungen auf die neue Validierung anpassen
- API-Hinweis im README ergänzen, damit Clients die neue Fehlerbehandlung kennen

## Testing
- pytest tests/test_webserver.py *(skipped: Flask nicht installiert)*

------
https://chatgpt.com/codex/tasks/task_e_68ff65710c448330b1db1beefe9f6c30