### PR TITLE
Allow clearing letters in /update_box handler

### DIFF
--- a/USBStick-Setup/files/usr/local/bin/webserver.py
+++ b/USBStick-Setup/files/usr/local/bin/webserver.py
@@ -306,9 +306,9 @@ def sanitize_ipv4(value: Optional[str], *, placeholder: str = SAFE_IP_PLACEHOLDE
     return str(address)
 
 
-def sanitize_letter(value, *, default: str = "") -> str:
+def sanitize_letter(value, *, default: Optional[str] = "", allow_empty: bool = False) -> Optional[str]:
     if value is None:
-        return default
+        return "" if allow_empty else default
 
     if isinstance(value, bytes):
         try:
@@ -320,7 +320,7 @@ def sanitize_letter(value, *, default: str = "") -> str:
 
     candidate = value.strip()
     if not candidate:
-        return default
+        return "" if allow_empty else default
 
     first_char = candidate[0]
     if "a" <= first_char <= "z":
@@ -917,8 +917,8 @@ def update_box():
 
         def _assign(index: int, raw_value):
             nonlocal changed_local
-            sanitized = sanitize_letter(raw_value)
-            if sanitized == "":
+            sanitized = sanitize_letter(raw_value, default=None, allow_empty=True)
+            if sanitized is None:
                 raw_repr = repr(raw_value)
                 return (
                     f"Ungültiger Buchstabe für {day} (Trigger {index + 1}, Quelle: {source}) – Eingabe {raw_repr} wird abgelehnt."
@@ -1021,9 +1021,9 @@ def update_box():
         trigger_index = None
 
     if day in DAYS and isinstance(trigger_index, int) and 0 <= trigger_index < TRIGGER_SLOTS:
-        if "letter" in data and isinstance(data.get("letter"), str):
-            sanitized_letter = sanitize_letter(data["letter"])
-            if not sanitized_letter:
+        if "letter" in data:
+            sanitized_letter = sanitize_letter(data.get("letter"), default=None, allow_empty=True)
+            if sanitized_letter is None:
                 return (
                     jsonify(
                         {

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -677,20 +677,18 @@ def test_update_box_rejects_invalid_letters(webserver_app):
     box["letters"]["mo"][1] = "B"
     module.save_config({"boxen": {"TestBox": box}, "boxOrder": ["TestBox"]})
 
-    baseline = json.loads(json.dumps(module.load_config()))
-
     response = client.post(
         "/update_box",
         json={"hostname": "TestBox", "letters": {"mo": ["  "]}},
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 200
     payload = response.get_json()
-    assert payload["status"] == "error"
-    assert "Ungültiger Buchstabe" in payload["message"]
+    assert payload == {"status": "success"}
 
-    config_after_letters = json.loads(json.dumps(module.load_config()))
-    assert config_after_letters == baseline
+    config_after_letters = module.load_config()
+    assert config_after_letters["boxen"]["TestBox"]["letters"]["mo"][0] == ""
+    assert config_after_letters["boxen"]["TestBox"]["letters"]["mo"][1] == "B"
 
     response = client.post(
         "/update_box",
@@ -702,8 +700,8 @@ def test_update_box_rejects_invalid_letters(webserver_app):
     assert payload["status"] == "error"
     assert "Ungültiger Buchstabe" in payload["message"]
 
-    config_after_direct = json.loads(json.dumps(module.load_config()))
-    assert config_after_direct == baseline
+    config_after_direct = module.load_config()
+    assert config_after_direct == config_after_letters
 
 
 def test_update_box_sanitizes_letters_and_transfer(webserver_app, monkeypatch):


### PR DESCRIPTION
## Summary
- let `sanitize_letter` distinguish between invalid and intentionally empty inputs
- permit empty letters when processing `/update_box` payloads so the new UI option succeeds
- refresh the `/update_box` invalid-letter test to cover the allowed empty case

## Testing
- pytest tests/test_webserver.py (skipped: test module has no collectors in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ff77e8d9c88330a2bfda357d183a0b